### PR TITLE
Implement -frecord-gitbom option

### DIFF
--- a/llvm-project/clang/docs/ClangCommandLineReference.rst
+++ b/llvm-project/clang/docs/ClangCommandLineReference.rst
@@ -889,6 +889,10 @@ Don't use ignorelist file for sanitizers
 
 .. option:: -frecord-command-line, -fno-record-command-line, -frecord-gcc-switches
 
+.. option:: -frecord-gitbom, -fno-record-gitbom
+
+Generate a section named .bom containing a gitref value. This gitref is computed by collecting the gitrefs of all the dependencies and then computing its gitref. It also creates a file with this gitref value as the name in the same dir as that of the object file.
+
 .. option:: -fsanitize-address-destructor=<arg>
 
 Set destructor type used in ASan instrumentation

--- a/llvm-project/clang/include/clang/Basic/CodeGenOptions.h
+++ b/llvm-project/clang/include/clang/Basic/CodeGenOptions.h
@@ -168,6 +168,14 @@ public:
   /// if non-empty.
   std::string RecordCommandLine;
 
+  /// The string containing the gitref of the .bom file.
+  std::string RecordGitBom;
+
+  /// List of dependent source/header files.
+  /// This is shared with DependencyOuputOptions.
+  /// This has same contents as Dependencies in DependencyCollector.
+  std::shared_ptr<std::vector<std::string>> BomDependencies;
+
   std::map<std::string, std::string> DebugPrefixMap;
   std::map<std::string, std::string> CoveragePrefixMap;
 

--- a/llvm-project/clang/include/clang/Basic/DiagnosticDriverKinds.td
+++ b/llvm-project/clang/include/clang/Basic/DiagnosticDriverKinds.td
@@ -207,6 +207,9 @@ def warn_drv_unknown_argument_clang_cl_with_suggestion : Warning<
   "unknown argument ignored in clang-cl '%0'; did you mean '%1'?">,
   InGroup<UnknownArgument>;
 
+def warn_drv_gitbom_requires_md : Warning<
+  "option '-frecord-gitbom' requires '-MD' or '-MF'">;
+
 def warn_drv_ycyu_different_arg_clang_cl : Warning<
   "support for '/Yc' and '/Yu' with different filenames not implemented yet; flags ignored">,
   InGroup<ClangClPch>;

--- a/llvm-project/clang/include/clang/Driver/Options.td
+++ b/llvm-project/clang/include/clang/Driver/Options.td
@@ -1288,6 +1288,10 @@ def frecord_command_line : Flag<["-"], "frecord-command-line">,
   Group<f_clang_Group>;
 def fno_record_command_line : Flag<["-"], "fno-record-command-line">,
   Group<f_clang_Group>;
+def frecord_gitbom : Flag<["-"], "frecord-gitbom">,
+  Group<f_clang_Group>;
+def fno_record_gitbom: Flag<["-"], "fno-record-gitbom">,
+  Group<f_clang_Group>;
 def : Flag<["-"], "frecord-gcc-switches">, Alias<frecord_command_line>;
 def : Flag<["-"], "fno-record-gcc-switches">, Alias<fno_record_command_line>;
 def fcommon : Flag<["-"], "fcommon">, Group<f_Group>,
@@ -4810,6 +4814,9 @@ def dwarf_debug_flags : Separate<["-"], "dwarf-debug-flags">,
 def record_command_line : Separate<["-"], "record-command-line">,
   HelpText<"The string to embed in the .LLVM.command.line section.">,
   MarshallingInfoString<CodeGenOpts<"RecordCommandLine">>;
+def record_gitbom: Separate<["-"], "record-gitbom">,
+  HelpText<"The string to embed in the .bom section.">,
+  MarshallingInfoString<CodeGenOpts<"RecordGitBom">>;
 def compress_debug_sections_EQ : Joined<["-", "--"], "compress-debug-sections=">,
     HelpText<"DWARF debug sections compression type">, Values<"none,zlib,zlib-gnu">,
     NormalizedValuesScope<"llvm::DebugCompressionType">, NormalizedValues<["None", "Z", "GNU"]>,

--- a/llvm-project/clang/include/clang/Frontend/DependencyOutputOptions.h
+++ b/llvm-project/clang/include/clang/Frontend/DependencyOutputOptions.h
@@ -9,6 +9,7 @@
 #ifndef LLVM_CLANG_FRONTEND_DEPENDENCYOUTPUTOPTIONS_H
 #define LLVM_CLANG_FRONTEND_DEPENDENCYOUTPUTOPTIONS_H
 
+#include <memory>
 #include <string>
 #include <vector>
 
@@ -66,6 +67,9 @@ public:
   /// A list of extra dependencies (filename and kind) to be used for every
   /// target.
   std::vector<std::pair<std::string, ExtraDepKind>> ExtraDeps;
+
+  /// List of dependencies; this is shared with CodeGenOptions.
+  std::shared_ptr<std::vector<std::string>> BomDependencies;
 
   /// In /showIncludes mode, pretend the main TU is a header with this name.
   std::string ShowIncludesPretendHeader;

--- a/llvm-project/clang/include/clang/Frontend/Utils.h
+++ b/llvm-project/clang/include/clang/Frontend/Utils.h
@@ -81,6 +81,13 @@ public:
   virtual void attachToPreprocessor(Preprocessor &PP);
   virtual void attachToASTReader(ASTReader &R);
   ArrayRef<std::string> getDependencies() const { return Dependencies; }
+  ArrayRef<std::string> getBomDependencies() const { return *BomDependencies; }
+  std::shared_ptr<std::vector<std::string>> getBomDependenciesPtr() const {
+    return BomDependencies;
+  }
+  void setBomDependenciesPtr(std::shared_ptr<std::vector<std::string>> Deps) {
+    BomDependencies = Deps;
+  }
 
   /// Called when a new file is seen. Return true if \p Filename should be added
   /// to the list of dependencies.
@@ -109,6 +116,7 @@ protected:
 private:
   llvm::StringSet<> Seen;
   std::vector<std::string> Dependencies;
+  std::shared_ptr<std::vector<std::string>> BomDependencies;
 };
 
 /// Builds a dependency file when attached to a Preprocessor (for includes) and
@@ -143,6 +151,7 @@ private:
   bool IncludeModuleFiles;
   DependencyOutputFormat OutputFormat;
   unsigned InputFileIndex;
+  std::shared_ptr<std::vector<std::string>> BomFiles;
 };
 
 /// Collects the dependencies for imported modules into a directory.  Users

--- a/llvm-project/clang/lib/CodeGen/CodeGenModule.h
+++ b/llvm-project/clang/lib/CodeGen/CodeGenModule.h
@@ -1592,6 +1592,12 @@ private:
   /// Emit the Clang commandline as llvm.commandline metadata.
   void EmitCommandLineMetadata();
 
+  /// Emit the gitbom as .gitbom metadata.
+  void EmitGitBomMetadata();
+
+  /// Compute the final gitref for all the dependencies.
+  std::string ComputeGitBomMetadata(std::vector<std::string> &Deps);
+
   /// Emit the module flag metadata used to pass options controlling the
   /// the backend to LLVM.
   void EmitBackendOptionsMetadata(const CodeGenOptions CodeGenOpts);

--- a/llvm-project/clang/lib/Frontend/CompilerInstance.cpp
+++ b/llvm-project/clang/lib/Frontend/CompilerInstance.cpp
@@ -492,9 +492,13 @@ void CompilerInstance::createPreprocessor(TranslationUnitKind TUKind) {
   }
 
   // Handle generating dependencies, if requested.
-  const DependencyOutputOptions &DepOpts = getDependencyOutputOpts();
-  if (!DepOpts.OutputFile.empty())
+  DependencyOutputOptions &DepOpts = getDependencyOutputOpts();
+  if (!DepOpts.OutputFile.empty()) {
+    DepOpts.BomDependencies = (std::make_shared<std::vector<std::string>>());
     addDependencyCollector(std::make_shared<DependencyFileGenerator>(DepOpts));
+    CodeGenOptions &CGOpts = getCodeGenOpts();
+    CGOpts.BomDependencies = DepOpts.BomDependencies;
+  }
   if (!DepOpts.DOTOutputFile.empty())
     AttachDependencyGraphGen(*PP, DepOpts.DOTOutputFile,
                              getHeaderSearchOpts().Sysroot);

--- a/llvm-project/clang/lib/Frontend/DependencyFile.cpp
+++ b/llvm-project/clang/lib/Frontend/DependencyFile.cpp
@@ -10,11 +10,11 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include "clang/Frontend/Utils.h"
 #include "clang/Basic/FileManager.h"
 #include "clang/Basic/SourceManager.h"
 #include "clang/Frontend/DependencyOutputOptions.h"
 #include "clang/Frontend/FrontendDiagnostic.h"
+#include "clang/Frontend/Utils.h"
 #include "clang/Lex/DirectoryLookup.h"
 #include "clang/Lex/ModuleMap.h"
 #include "clang/Lex/PPCallbacks.h"
@@ -23,7 +23,9 @@
 #include "llvm/ADT/StringSet.h"
 #include "llvm/ADT/StringSwitch.h"
 #include "llvm/Support/FileSystem.h"
+#include "llvm/Support/MemoryBuffer.h"
 #include "llvm/Support/Path.h"
+#include "llvm/Support/SHA1.h"
 #include "llvm/Support/raw_ostream.h"
 
 using namespace clang;
@@ -154,6 +156,7 @@ bool DependencyCollector::addDependency(StringRef Filename) {
 
   if (Seen.insert(SearchPath).second) {
     Dependencies.push_back(std::string(Filename));
+    BomDependencies->push_back(std::string(Filename));
     return true;
   }
   return false;
@@ -192,6 +195,7 @@ DependencyFileGenerator::DependencyFileGenerator(
       AddMissingHeaderDeps(Opts.AddMissingHeaderDeps), SeenMissingHeader(false),
       IncludeModuleFiles(Opts.IncludeModuleFiles),
       OutputFormat(Opts.OutputFormat), InputFileIndex(0) {
+  setBomDependenciesPtr(Opts.BomDependencies);
   for (const auto &ExtraDep : Opts.ExtraDeps) {
     if (addDependency(ExtraDep.first))
       ++InputFileIndex;

--- a/llvm-project/clang/test/CodeGen/Inputs/gitbom.c
+++ b/llvm-project/clang/test/CodeGen/Inputs/gitbom.c
@@ -1,0 +1,4 @@
+#include "gitbom.h"
+int add(int x, int y) {
+  return x + y;
+}

--- a/llvm-project/clang/test/CodeGen/Inputs/gitbom.h
+++ b/llvm-project/clang/test/CodeGen/Inputs/gitbom.h
@@ -1,0 +1,1 @@
+int add(int, int);

--- a/llvm-project/clang/test/CodeGen/gitbom.c
+++ b/llvm-project/clang/test/CodeGen/gitbom.c
@@ -1,0 +1,4 @@
+#include "gitbom.h"
+int add(int x, int y) {
+  return x + y;
+}

--- a/llvm-project/clang/test/CodeGen/gitbom_test.c
+++ b/llvm-project/clang/test/CodeGen/gitbom_test.c
@@ -1,0 +1,3 @@
+// RUN: %clang -c -frecord-gitbom -MD -o %t.o %S/Inputs/gitbom.c -I%S/Inputs/gitbom.h
+// RUN: llvm-readelf -p ".bom" %t.o | FileCheck --check-prefix=BOM_IDENTIFIER %s
+// BOM_IDENTIFIER: [     0] 5016da29beed4d19143174ae53d5a69d5fa2afa4

--- a/llvm-project/clang/test/Driver/clang_f_opts.c
+++ b/llvm-project/clang/test/Driver/clang_f_opts.c
@@ -555,6 +555,8 @@
 // CHECK-RECORD-GCC-SWITCHES: "-record-command-line"
 // CHECK-NO-RECORD-GCC-SWITCHES-NOT: "-record-command-line"
 // CHECK-RECORD-GCC-SWITCHES-ERROR: error: unsupported option '-frecord-command-line' for target
+// CHECK-RECORD-GITBOM: "-record-gitbom"
+// CHECK-RECORD-GITBOM-NOT: "-record-gitbom"
 // Test when clang is in a path containing a space.
 // The initial `rm` is a workaround for https://openradar.appspot.com/FB8914243
 // (Scenario: Run tests once, `clang` gets copied and run at new location and signature
@@ -567,6 +569,8 @@
 // RUN: "%t.r/with spaces/clang" -### -S -target x86_64-unknown-linux -frecord-gcc-switches %s 2>&1 | FileCheck -check-prefix=CHECK-RECORD-GCC-SWITCHES-ESCAPED %s
 // CHECK-RECORD-GCC-SWITCHES-ESCAPED: "-record-command-line" "{{.+}}with\\ spaces{{.+}}"
 
+// RUN: %clang -### -S -target x86_64-unknown-linux -frecord-gitbom %s 2>&1 | FileCheck -check-prefix=CHECK-RECORD-GITBOM %s
+// RUN: %clang -### -S -target x86_64-unknown-linux -fno-record-gitbom %s 2>&1 | FileCheck -check-prefix=CHECK-NO-RECORD-GITBOM %s
 // RUN: %clang -### -S -ftrivial-auto-var-init=uninitialized %s 2>&1 | FileCheck -check-prefix=CHECK-TRIVIAL-UNINIT %s
 // RUN: %clang -### -S -ftrivial-auto-var-init=pattern %s 2>&1 | FileCheck -check-prefix=CHECK-TRIVIAL-PATTERN %s
 // RUN: %clang -### -S -ftrivial-auto-var-init=zero -enable-trivial-auto-var-init-zero-knowing-it-will-be-removed-from-clang %s 2>&1 | FileCheck -check-prefix=CHECK-TRIVIAL-ZERO-GOOD %s

--- a/llvm-project/llvm/include/llvm/CodeGen/AsmPrinter.h
+++ b/llvm-project/llvm/include/llvm/CodeGen/AsmPrinter.h
@@ -793,6 +793,8 @@ private:
   void emitModuleIdents(Module &M);
   /// Emit bytes for llvm.commandline metadata.
   void emitModuleCommandLines(Module &M);
+  /// Emit bytes for .bom
+  void emitModuleGitBom(Module &M);
 
   GCMetadataPrinter *GetOrCreateGCPrinter(GCStrategy &S);
   /// Emit GlobalAlias or GlobalIFunc.

--- a/llvm-project/llvm/include/llvm/CodeGen/TargetLoweringObjectFileImpl.h
+++ b/llvm-project/llvm/include/llvm/CodeGen/TargetLoweringObjectFileImpl.h
@@ -109,6 +109,7 @@ public:
                                         const TargetMachine &TM) const override;
 
   MCSection *getSectionForCommandLines() const override;
+  MCSection *getSectionForGitBom() const override;
 };
 
 class TargetLoweringObjectFileMachO : public TargetLoweringObjectFile {

--- a/llvm-project/llvm/include/llvm/Target/TargetLoweringObjectFile.h
+++ b/llvm-project/llvm/include/llvm/Target/TargetLoweringObjectFile.h
@@ -235,6 +235,10 @@ public:
     return nullptr;
   }
 
+  /// If supported, return the section to use for the .bom
+  /// metadata. Otherwise, return nullptr.
+  virtual MCSection *getSectionForGitBom() const { return nullptr; }
+
   /// On targets that use separate function descriptor symbols, return a section
   /// for the descriptor given its symbol. Use only with defined functions.
   virtual MCSection *

--- a/llvm-project/llvm/lib/CodeGen/AsmPrinter/AsmPrinter.cpp
+++ b/llvm-project/llvm/lib/CodeGen/AsmPrinter/AsmPrinter.cpp
@@ -1875,6 +1875,9 @@ bool AsmPrinter::doFinalization(Module &M) {
   // Emit bytes for llvm.commandline metadata.
   emitModuleCommandLines(M);
 
+  // Emit bytes for .bom metadata
+  emitModuleGitBom(M);
+
   // Emit __morestack address if needed for indirect calls.
   if (MMI->usesMorestackAddr()) {
     Align Alignment(1);
@@ -2368,6 +2371,28 @@ void AsmPrinter::emitModuleIdents(Module &M) {
       OutStreamer->emitIdent(S->getString());
     }
   }
+}
+
+void AsmPrinter::emitModuleGitBom(Module &M) {
+  MCSection *CommandLine = getObjFileLowering().getSectionForGitBom();
+  if (!CommandLine)
+    return;
+
+  const NamedMDNode *NMD = M.getNamedMetadata(".bom");
+  if (!NMD || !NMD->getNumOperands())
+    return;
+
+  OutStreamer->PushSection();
+  OutStreamer->SwitchSection(CommandLine);
+
+  for (unsigned i = 0, e = NMD->getNumOperands(); i != e; ++i) {
+    const MDNode *N = NMD->getOperand(i);
+    assert(N->getNumOperands() == 1 &&
+           ".bom metadata entry can have only one operand");
+    const MDString *S = cast<MDString>(N->getOperand(0));
+    OutStreamer->emitBytes(S->getString());
+  }
+  OutStreamer->PopSection();
 }
 
 void AsmPrinter::emitModuleCommandLines(Module &M) {

--- a/llvm-project/llvm/lib/CodeGen/TargetLoweringObjectFileImpl.cpp
+++ b/llvm-project/llvm/lib/CodeGen/TargetLoweringObjectFileImpl.cpp
@@ -1108,6 +1108,12 @@ const MCExpr *TargetLoweringObjectFileELF::lowerDSOLocalEquivalent(
                                  getContext());
 }
 
+MCSection *TargetLoweringObjectFileELF::getSectionForGitBom() const {
+  // .bom
+  return getContext().getELFSection(".bom", ELF::SHT_PROGBITS,
+                                    ELF::SHF_MERGE | ELF::SHF_STRINGS, 1);
+}
+
 MCSection *TargetLoweringObjectFileELF::getSectionForCommandLines() const {
   // Use ".GCC.command.line" since this feature is to support clang's
   // -frecord-gcc-switches which in turn attempts to mimic GCC's switch of the


### PR DESCRIPTION
-frecord-gitbom option creates
1) a file containing the gitrefs of all the dependencies in the same dir as that of the object file. The name of this file is the same as its gitref. 
2) a .bom section containing the name of the file (created as above).

Signed-off-by: Bharathi Seshadri <bseshadr@cisco.com>