### PR TITLE
Write 20byte hash to the .bom section

### DIFF
--- a/llvm-project/clang/test/CodeGen/gitbom_test.c
+++ b/llvm-project/clang/test/CodeGen/gitbom_test.c
@@ -2,7 +2,6 @@
 // RUN:  %clang -c -frecord-gitbom -MD -o %t/gitbom.o %S/Inputs/gitbom.c -I%S/Inputs/gitbom.h
 // RUN: llvm-readelf -p ".bom" %t/gitbom.o | FileCheck --check-prefix=BOM_IDENTIFIER %s
 // RUN: cat %t/.gitbom/object/50/16da29beed4d19143174ae53d5a69d5fa2afa4 | FileCheck --check-prefix=BOM_FILE_CONTENTS %s
-// BOM_IDENTIFIER: [     0] 5016da29beed4d19143174ae53d5a69d5fa2afa4
-
-//BOM_FILE_CONTENTS: blob 6e00bf3ad31d164ffc9a1a64a377857607a24085
-//BOM_FILE_CONTENTS: blob c7184931bb3205d7eff290af1860fbed5f963fb5
+// BOM_IDENTIFIER: [     0] P..)..M..1t.S..._...
+// BOM_FILE_CONTENTS: blob 6e00bf3ad31d164ffc9a1a64a377857607a24085
+// BOM_FILE_CONTENTS: blob c7184931bb3205d7eff290af1860fbed5f963fb5

--- a/llvm-project/lld/ELF/SyntheticSections.cpp
+++ b/llvm-project/lld/ELF/SyntheticSections.cpp
@@ -151,8 +151,9 @@ template <class ELFT> BomSection<ELFT> *BomSection<ELFT>::create() {
       StringRef content = toStringRef(sec->data());
       // TODO: check if the file exists in the map
       FileHashBomMap::iterator Iter = BomMap.find(filename);
-      if (Iter != BomMap.end())
-        Iter->second.second = content.str();
+      if (Iter != BomMap.end()) {
+        Iter->second.second = convertToHex(content.str());
+      }
     }
   }
 
@@ -200,7 +201,7 @@ template <class ELFT> BomSection<ELFT> *BomSection<ELFT>::create() {
   }
   OS << hashContents;
   if (create) {
-    return make<BomSection<ELFT>>(gitRef);
+    return make<BomSection<ELFT>>(Result.str());
   }
   return nullptr;
 }

--- a/llvm-project/lld/test/ELF/Inputs/gitbom.s
+++ b/llvm-project/lld/test/ELF/Inputs/gitbom.s
@@ -1,0 +1,56 @@
+	.text
+	.file	"gitbom.c"
+	.globl	add                             # -- Begin function add
+	.p2align	4, 0x90
+	.type	add,@function
+add:                                    # @add
+	.cfi_startproc
+# %bb.0:                                # %entry
+	pushq	%rbp
+	.cfi_def_cfa_offset 16
+	.cfi_offset %rbp, -16
+	movq	%rsp, %rbp
+	.cfi_def_cfa_register %rbp
+	movl	%edi, -4(%rbp)
+	movl	%esi, -8(%rbp)
+	movl	-4(%rbp), %eax
+	addl	-8(%rbp), %eax
+	popq	%rbp
+	.cfi_def_cfa %rsp, 8
+	retq
+.Lfunc_end0:
+	.size	add, .Lfunc_end0-add
+	.cfi_endproc
+                                        # -- End function
+	.globl	main                            # -- Begin function main
+	.p2align	4, 0x90
+	.type	main,@function
+main:                                   # @main
+	.cfi_startproc
+# %bb.0:                                # %entry
+	pushq	%rbp
+	.cfi_def_cfa_offset 16
+	.cfi_offset %rbp, -16
+	movq	%rsp, %rbp
+	.cfi_def_cfa_register %rbp
+	subq	$16, %rsp
+	movl	$0, -4(%rbp)
+	movl	$2, %edi
+	movl	$3, %esi
+	callq	add
+	xorl	%eax, %eax
+	addq	$16, %rsp
+	popq	%rbp
+	.cfi_def_cfa %rsp, 8
+	retq
+.Lfunc_end1:
+	.size	main, .Lfunc_end1-main
+	.cfi_endproc
+                                        # -- End function
+	.ident	"clang version 13.0.0 (git@github.com:git-bom/llvm-gitbom.git f127d76c6bf175352a60f640a7af8e1fa8c5366d)"
+	.section	.bom,"M",@progbits,1
+	.ascii	"\n\327\366$cV\"~\267o\340\330\253Y\362=\377\276\231i"
+	.text
+	.section	".note.GNU-stack","",@progbits
+	.addrsig
+	.addrsig_sym add

--- a/llvm-project/lld/test/ELF/gitbom_test.s
+++ b/llvm-project/lld/test/ELF/gitbom_test.s
@@ -1,0 +1,13 @@
+# RUN: rm -rf %t && mkdir %t
+# RUN: llvm-mc -filetype=obj -triple=x86_64-pc-linux %S/Inputs/gitbom.s -o %t/gitbom.o
+# RUN: ld.lld %t/gitbom.o -e main --gitbom -o %t/gitbom.exe
+# RUN: llvm-readobj -p ".bom" %t/gitbom.exe | FileCheck --check-prefix=GITBOM %s
+# RUN: cat %t/.gitbom/object/c3/c5ce3656b2529dec7006a302bdfee02c1f0e2c | FileCheck --check-prefix=BOM_FILE %s
+# GITBOM: File: {{.*}}
+# GITBOM-NEXT: Format: elf64-x86-64
+# GITBOM-NEXT: Arch: x86_64
+# GITBOM-NEXT: AddressSize: 64bit
+# GITBOM-NEXT: LoadName: <Not found>
+# GITBOM-NEXT: String dump of section '.bom':
+# GITBOM-NEXT: [     0] ...6V.R..p......,..,
+# BOM_FILE: blob aaee289ee5320b56336f104e712ea31ad7a64c35 bom 0ad7f6246356227eb76fe0d8ab59f23dffbe9969


### PR DESCRIPTION
Write 20 bytes of hash to the .bom section instead of 40 bytes representing the hex value. 
This change is done both to lld and clang.

Signed-off-by: Bharathi Seshadri <bseshadr@cisco.com>