### PR TITLE
change name of .gitbom sub-directory

### DIFF
--- a/llvm-project/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/llvm-project/clang/lib/Driver/ToolChains/Clang.cpp
@@ -6817,7 +6817,7 @@ void Clang::ConstructJob(Compilation &C, const JobAction &JA,
       llvm::sys::path::remove_filename(OutputPath);
     }
     llvm::sys::path::append(OutputPath, ".gitbom");
-    llvm::sys::path::append(OutputPath, "object");
+    llvm::sys::path::append(OutputPath, "objects");
     CmdArgs.push_back(Args.MakeArgString(OutputPath));
     // Create the .bom/objects directory
     auto EC =

--- a/llvm-project/clang/test/CodeGen/gitbom_test.c
+++ b/llvm-project/clang/test/CodeGen/gitbom_test.c
@@ -1,7 +1,7 @@
 // RUN: rm -rf %t && mkdir %t
 // RUN:  %clang -c -frecord-gitbom -o %t/gitbom.o %S/Inputs/gitbom.c -I%S/Inputs/gitbom.h
 // RUN: llvm-readelf -p ".bom" %t/gitbom.o | FileCheck --check-prefix=BOM_IDENTIFIER %s
-// RUN: cat %t/.gitbom/object/50/16da29beed4d19143174ae53d5a69d5fa2afa4 | FileCheck --check-prefix=BOM_FILE_CONTENTS %s
+// RUN: cat %t/.gitbom/objects/50/16da29beed4d19143174ae53d5a69d5fa2afa4 | FileCheck --check-prefix=BOM_FILE_CONTENTS %s
 // BOM_IDENTIFIER: [     0] P..)..M..1t.S..._...
 // BOM_FILE_CONTENTS: blob 6e00bf3ad31d164ffc9a1a64a377857607a24085
 // BOM_FILE_CONTENTS: blob c7184931bb3205d7eff290af1860fbed5f963fb5

--- a/llvm-project/clang/test/CodeGen/gitbom_test_MD.c
+++ b/llvm-project/clang/test/CodeGen/gitbom_test_MD.c
@@ -1,7 +1,7 @@
 // RUN: rm -rf %t && mkdir %t
 // RUN:  %clang -c -frecord-gitbom -MD -o %t/gitbom.o %S/Inputs/gitbom.c -I%S/Inputs/gitbom.h
 // RUN: llvm-readelf -p ".bom" %t/gitbom.o | FileCheck --check-prefix=BOM_IDENTIFIER %s
-// RUN: cat %t/.gitbom/object/50/16da29beed4d19143174ae53d5a69d5fa2afa4 | FileCheck --check-prefix=BOM_FILE_CONTENTS %s
+// RUN: cat %t/.gitbom/objects/50/16da29beed4d19143174ae53d5a69d5fa2afa4 | FileCheck --check-prefix=BOM_FILE_CONTENTS %s
 // BOM_IDENTIFIER: [     0] P..)..M..1t.S..._...
 // BOM_FILE_CONTENTS: blob 6e00bf3ad31d164ffc9a1a64a377857607a24085
 // BOM_FILE_CONTENTS: blob c7184931bb3205d7eff290af1860fbed5f963fb5

--- a/llvm-project/lld/ELF/SyntheticSections.cpp
+++ b/llvm-project/lld/ELF/SyntheticSections.cpp
@@ -189,7 +189,7 @@ std::unique_ptr<BomSection<ELFT>> BomSection<ELFT>::create() {
     SmallString<128> CurDir("./");
     gitRefPath = CurDir;
   }
-  llvm::sys::path::append(gitRefPath, ".gitbom/object");
+  llvm::sys::path::append(gitRefPath, ".gitbom/objects");
   llvm::sys::path::append(gitRefPath, gitRef.substr(0, 2));
   std::error_code EC;
   EC = llvm::sys::fs::create_directories(gitRefPath, true);

--- a/llvm-project/lld/test/ELF/gitbom_test.s
+++ b/llvm-project/lld/test/ELF/gitbom_test.s
@@ -2,7 +2,7 @@
 # RUN: llvm-mc -filetype=obj -triple=x86_64-pc-linux %S/Inputs/gitbom.s -o %t/gitbom.o
 # RUN: ld.lld %t/gitbom.o -e main --gitbom -o %t/gitbom.exe
 # RUN: llvm-readobj -p ".bom" %t/gitbom.exe | FileCheck --check-prefix=GITBOM %s
-# RUN: cat %t/.gitbom/object/05/ec1279f15fa8c76bab1645e5f2b2d1ba39c10a | FileCheck --check-prefix=BOM_FILE %s
+# RUN: cat %t/.gitbom/objects/05/ec1279f15fa8c76bab1645e5f2b2d1ba39c10a | FileCheck --check-prefix=BOM_FILE %s
 # GITBOM: File: {{.*}}
 # GITBOM-NEXT: Format: elf64-x86-64
 # GITBOM-NEXT: Arch: x86_64


### PR DESCRIPTION
To maintain compatibility with bomsh tool, the gitbom sub-directory is changed from .gitbom/object to .gitbom/objects

Signed-off-by: bharsesh <bharathi.seshadri@gmail.com>