### PR TITLE
clang, lld: Specify directory to store gitbom files

### DIFF
--- a/llvm-project/clang/include/clang/Driver/Options.td
+++ b/llvm-project/clang/include/clang/Driver/Options.td
@@ -1342,6 +1342,8 @@ def fno_record_command_line : Flag<["-"], "fno-record-command-line">,
   Group<f_clang_Group>;
 def frecord_gitbom : Flag<["-"], "frecord-gitbom">,
   Group<f_clang_Group>;
+def frecord_gitbom_EQ : Joined<["-"], "frecord-gitbom=">,
+  Group<f_clang_Group>, MetaVarName<"<directory>">;
 def fno_record_gitbom: Flag<["-"], "fno-record-gitbom">,
   Group<f_clang_Group>;
 def : Flag<["-"], "frecord-gcc-switches">, Alias<frecord_command_line>;

--- a/llvm-project/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/llvm-project/clang/lib/Driver/ToolChains/Clang.cpp
@@ -6814,11 +6814,11 @@ void Clang::ConstructJob(Compilation &C, const JobAction &JA,
     CmdArgs.push_back("-record-gitbom");
 
     // Determine directory to store gitbom files in this order of precedence.
-    // 1. If LLVM_GITBOM_DIR environment variable is set, use this location.
+    // 1. If GITBOM_DIR environment variable is set, use this location.
     // 2. Use the directory name passed with frecord-gitbom option.
     // 3. Default is to write the bom files in the same directory as the object
     // file.
-    if (char *env = ::getenv("LLVM_GITBOM_DIR"))
+    if (char *env = ::getenv("GITBOM_DIR"))
       OutputPath = env;
     else {
       auto GitBomDir = Args.getLastArg(options::OPT_frecord_gitbom_EQ);

--- a/llvm-project/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/llvm-project/clang/lib/Driver/ToolChains/Clang.cpp
@@ -6805,16 +6805,32 @@ void Clang::ConstructJob(Compilation &C, const JobAction &JA,
 
   const char *Exec = D.getClangProgramPath();
 
-  auto GitBomRecordSwitches = Args.hasFlag(
-      options::OPT_frecord_gitbom, options::OPT_fno_record_gitbom, false);
+  auto GitBomRecordSwitches =
+      Args.hasFlag(options::OPT_frecord_gitbom, options::OPT_frecord_gitbom_EQ,
+                   options::OPT_fno_record_gitbom, false);
 
   if (GitBomRecordSwitches) {
     SmallString<128> OutputPath;
     CmdArgs.push_back("-record-gitbom");
-    // Pass the dir name where the gitbom file should be created.
-    if (Arg *OutputOpt = Args.getLastArg(options::OPT_o)) {
-      OutputPath = OutputOpt->getValue();
-      llvm::sys::path::remove_filename(OutputPath);
+
+    // Determine directory to store gitbom files in this order of precedence.
+    // 1. If LLVM_GITBOM_DIR environment variable is set, use this location.
+    // 2. Use the directory name passed with frecord-gitbom option.
+    // 3. Default is to write the bom files in the same directory as the object
+    // file.
+    if (char *env = ::getenv("LLVM_GITBOM_DIR"))
+      OutputPath = env;
+    else {
+      auto GitBomDir = Args.getLastArg(options::OPT_frecord_gitbom_EQ);
+      if (GitBomDir) {
+        auto ArgValue = GitBomDir->getValue();
+        OutputPath = ArgValue;
+      }
+      // Pass the dir name where the object file is created.
+      else if (Arg *OutputOpt = Args.getLastArg(options::OPT_o)) {
+        OutputPath = OutputOpt->getValue();
+        llvm::sys::path::remove_filename(OutputPath);
+      }
     }
     llvm::sys::path::append(OutputPath, ".gitbom");
     llvm::sys::path::append(OutputPath, "objects");

--- a/llvm-project/clang/test/CodeGen/gitbom_test.c
+++ b/llvm-project/clang/test/CodeGen/gitbom_test.c
@@ -1,7 +1,14 @@
 // RUN: rm -rf %t && mkdir %t
-// RUN:  %clang -c -frecord-gitbom -o %t/gitbom.o %S/Inputs/gitbom.c -I%S/Inputs/gitbom.h
-// RUN: llvm-readelf -p ".bom" %t/gitbom.o | FileCheck --check-prefix=BOM_IDENTIFIER %s
+
+// RUN: %clang -c -frecord-gitbom -o %t/gitbom_1.o %S/Inputs/gitbom.c -I%S/Inputs/gitbom.h
+// RUN: llvm-readelf -p ".bom" %t/gitbom_1.o | FileCheck --check-prefix=BOM_IDENTIFIER %s
 // RUN: cat %t/.gitbom/objects/50/16da29beed4d19143174ae53d5a69d5fa2afa4 | FileCheck --check-prefix=BOM_FILE_CONTENTS %s
+
+// RUN: %clang -c -frecord-gitbom=%t/gitbomdir -o %t/gitbom_2.o %S/Inputs/gitbom.c -I%S/Inputs/gitbom.h
+// RUN: cat %t/gitbomdir/.gitbom/objects/50/16da29beed4d19143174ae53d5a69d5fa2afa4 | FileCheck --check-prefix=BOM_FILE_CONTENTS %s
+
+// RUN: env LLVM_GITBOM_DIR="%t/env_gitbom_dir" %clang -c -frecord-gitbom=%t/gitbomdir -o %t/gitbom_3.o %S/Inputs/gitbom.c -I%S/Inputs/gitbom.h
+// RUN: cat %t/env_gitbom_dir/.gitbom/objects/50/16da29beed4d19143174ae53d5a69d5fa2afa4 | FileCheck --check-prefix=BOM_FILE_CONTENTS %s
 // BOM_IDENTIFIER: [     0] P..)..M..1t.S..._...
 // BOM_FILE_CONTENTS: blob 6e00bf3ad31d164ffc9a1a64a377857607a24085
 // BOM_FILE_CONTENTS: blob c7184931bb3205d7eff290af1860fbed5f963fb5

--- a/llvm-project/clang/test/CodeGen/gitbom_test.c
+++ b/llvm-project/clang/test/CodeGen/gitbom_test.c
@@ -5,10 +5,23 @@
 // RUN: cat %t/.gitbom/objects/50/16da29beed4d19143174ae53d5a69d5fa2afa4 | FileCheck --check-prefix=BOM_FILE_CONTENTS %s
 
 // RUN: %clang -c -frecord-gitbom=%t/gitbomdir -o %t/gitbom_2.o %S/Inputs/gitbom.c -I%S/Inputs/gitbom.h
+// RUN: llvm-readelf -p ".bom" %t/gitbom_2.o | FileCheck --check-prefix=BOM_IDENTIFIER %s
 // RUN: cat %t/gitbomdir/.gitbom/objects/50/16da29beed4d19143174ae53d5a69d5fa2afa4 | FileCheck --check-prefix=BOM_FILE_CONTENTS %s
 
 // RUN: env GITBOM_DIR="%t/env_gitbom_dir" %clang -c -frecord-gitbom=%t/gitbomdir -o %t/gitbom_3.o %S/Inputs/gitbom.c -I%S/Inputs/gitbom.h
+// RUN: llvm-readelf -p ".bom" %t/gitbom_3.o | FileCheck --check-prefix=BOM_IDENTIFIER %s
 // RUN: cat %t/env_gitbom_dir/.gitbom/objects/50/16da29beed4d19143174ae53d5a69d5fa2afa4 | FileCheck --check-prefix=BOM_FILE_CONTENTS %s
+
+// RUN: rm -f %t/env_gitbom_dir/.gitbom/objects/50/16da29beed4d19143174ae53d5a69d5fa2afa4
+// RUN: env GITBOM_DIR="%t/env_gitbom_dir" %clang -c -o %t/gitbom_4.o %S/Inputs/gitbom.c -I%S/Inputs/gitbom.h
+// RUN: llvm-readelf -p ".bom" %t/gitbom_4.o | FileCheck --check-prefix=BOM_IDENTIFIER %s
+// RUN: cat %t/env_gitbom_dir/.gitbom/objects/50/16da29beed4d19143174ae53d5a69d5fa2afa4 | FileCheck --check-prefix=BOM_FILE_CONTENTS %s
+
+// RUN: rm -f %t/.gitbom/objects/50/16da29beed4d19143174ae53d5a69d5fa2afa4
+// RUN: env GITBOM_DIR= %clang -c -frecord-gitbom -o %t/gitbom_5.o %S/Inputs/gitbom.c -I%S/Inputs/gitbom.h
+// RUN: llvm-readelf -p ".bom" %t/gitbom_5.o | FileCheck --check-prefix=BOM_IDENTIFIER %s
+// RUN: cat %t/.gitbom/objects/50/16da29beed4d19143174ae53d5a69d5fa2afa4 | FileCheck --check-prefix=BOM_FILE_CONTENTS %s
+
 // BOM_IDENTIFIER: [     0] P..)..M..1t.S..._...
 // BOM_FILE_CONTENTS: blob 6e00bf3ad31d164ffc9a1a64a377857607a24085
 // BOM_FILE_CONTENTS: blob c7184931bb3205d7eff290af1860fbed5f963fb5

--- a/llvm-project/clang/test/CodeGen/gitbom_test.c
+++ b/llvm-project/clang/test/CodeGen/gitbom_test.c
@@ -7,7 +7,7 @@
 // RUN: %clang -c -frecord-gitbom=%t/gitbomdir -o %t/gitbom_2.o %S/Inputs/gitbom.c -I%S/Inputs/gitbom.h
 // RUN: cat %t/gitbomdir/.gitbom/objects/50/16da29beed4d19143174ae53d5a69d5fa2afa4 | FileCheck --check-prefix=BOM_FILE_CONTENTS %s
 
-// RUN: env LLVM_GITBOM_DIR="%t/env_gitbom_dir" %clang -c -frecord-gitbom=%t/gitbomdir -o %t/gitbom_3.o %S/Inputs/gitbom.c -I%S/Inputs/gitbom.h
+// RUN: env GITBOM_DIR="%t/env_gitbom_dir" %clang -c -frecord-gitbom=%t/gitbomdir -o %t/gitbom_3.o %S/Inputs/gitbom.c -I%S/Inputs/gitbom.h
 // RUN: cat %t/env_gitbom_dir/.gitbom/objects/50/16da29beed4d19143174ae53d5a69d5fa2afa4 | FileCheck --check-prefix=BOM_FILE_CONTENTS %s
 // BOM_IDENTIFIER: [     0] P..)..M..1t.S..._...
 // BOM_FILE_CONTENTS: blob 6e00bf3ad31d164ffc9a1a64a377857607a24085

--- a/llvm-project/lld/ELF/Config.h
+++ b/llvm-project/lld/ELF/Config.h
@@ -176,7 +176,7 @@ struct Configuration {
   bool fortranCommon;
   bool gcSections;
   bool gdbIndex;
-  bool gitBom = false;
+  std::string gitBomDir;
   bool gnuHash = false;
   bool gnuUnique;
   bool hasDynSymTab;

--- a/llvm-project/lld/ELF/Driver.cpp
+++ b/llvm-project/lld/ELF/Driver.cpp
@@ -1039,7 +1039,7 @@ static void readConfigs(opt::InputArgList &args) {
   if (gitBomArg) {
     SmallString<128> gitRefPath;
     // Environment variable takes precedence over the --gitbom= option.
-    const char *gitBomDir = getenv("LLVM_GITBOM_DIR");
+    const char *gitBomDir = getenv("GITBOM_DIR");
     if (gitBomDir) {
       gitRefPath = StringRef(gitBomDir);
     } else {

--- a/llvm-project/lld/ELF/Options.td
+++ b/llvm-project/lld/ELF/Options.td
@@ -55,6 +55,10 @@ def build_id: F<"build-id">, HelpText<"Alias for --build-id=fast">;
 def build_id_eq: J<"build-id=">, HelpText<"Generate build ID note">,
   MetaVarName<"[fast,md5,sha1,uuid,0x<hexstring>]">;
 
+def gitbom: F<"gitbom">, HelpText<"Generate gitBOM data">;
+def gitbom_eq: J<"gitbom=">, HelpText<"Generate gitBOM data in the given directory">,
+  MetaVarName<"<dir>">;
+
 defm check_sections: B<"check-sections",
     "Check section addresses for overlaps (default)",
     "Do not check section addresses for overlaps">;
@@ -233,10 +237,6 @@ defm gc_sections: B<"gc-sections",
 defm gdb_index: BB<"gdb-index",
     "Generate .gdb_index section",
     "Do not generate .gdb_index section (default)">;
-
-defm gitbom: BB<"gitbom",
-  "Enable generation of .bom section",
-  "Disable generation of .bom section">;
 
 defm gnu_unique: BB<"gnu-unique",
   "Enable STB_GNU_UNIQUE symbol binding (default)",

--- a/llvm-project/lld/ELF/SyntheticSections.cpp
+++ b/llvm-project/lld/ELF/SyntheticSections.cpp
@@ -126,8 +126,6 @@ std::unique_ptr<BomSection<ELFT>> BomSection<ELFT>::create() {
 
   FileHashBomMap BomMap;
   std::error_code ec;
-  std::string filename = config->outputFile.str();
-  StringRef BomFile = StringRef(filename);
   for (StringRef path : config->dependencyFiles) {
     llvm::ErrorOr<std::unique_ptr<llvm::MemoryBuffer>> fileBuf =
         llvm::MemoryBuffer::getFile(path, /*IsText=*/true);
@@ -182,14 +180,8 @@ std::unique_ptr<BomSection<ELFT>> BomSection<ELFT>::create() {
   auto Result = Hash.final();
   gitRef = convertToHex(Result);
 
-  // Generate Bom File
-  SmallString<128> gitRefPath(BomFile);
-  llvm::sys::path::remove_filename(gitRefPath);
-  if (gitRefPath.empty()) {
-    SmallString<128> CurDir("./");
-    gitRefPath = CurDir;
-  }
-  llvm::sys::path::append(gitRefPath, ".gitbom/objects");
+  SmallString<128> gitRefPath;
+  gitRefPath = StringRef(config->gitBomDir);
   llvm::sys::path::append(gitRefPath, gitRef.substr(0, 2));
   std::error_code EC;
   EC = llvm::sys::fs::create_directories(gitRefPath, true);

--- a/llvm-project/lld/ELF/Writer.cpp
+++ b/llvm-project/lld/ELF/Writer.cpp
@@ -334,7 +334,7 @@ template <class ELFT> void elf::createSyntheticSections() {
       add(*in.mipsReginfo);
   }
 
-  if (config->gitBom) {
+  if (config->gitBomDir.length()) {
     if ((in.gitBom = BomSection<ELFT>::create()))
       add(*in.gitBom);
   }

--- a/llvm-project/lld/test/ELF/gitbom_test.s
+++ b/llvm-project/lld/test/ELF/gitbom_test.s
@@ -4,11 +4,22 @@
 # RUN: llvm-readobj -p ".bom" %t/gitbom.exe | FileCheck --check-prefix=GITBOM %s
 # RUN: cat %t/.gitbom/objects/05/ec1279f15fa8c76bab1645e5f2b2d1ba39c10a | FileCheck --check-prefix=BOM_FILE %s
 
-# RUN: ld.lld %t/gitbom.o -e main --gitbom=%t/gitbom_dir -o %t/gitbom.exe
+# RUN: ld.lld %t/gitbom.o -e main --gitbom=%t/gitbom_dir -o %t/gitbom_1.exe
+# RUN: llvm-readobj -p ".bom" %t/gitbom_1.exe | FileCheck --check-prefix=GITBOM %s
 # RUN: cat %t/gitbom_dir/.gitbom/objects/05/ec1279f15fa8c76bab1645e5f2b2d1ba39c10a | FileCheck --check-prefix=BOM_FILE %s
 
-# RUN: env GITBOM_DIR="%t/env_gitbom_dir" ld.lld %t/gitbom.o -e main --gitbom=%t/gitbom_dir -o %t/gitbom.exe
+# RUN: env GITBOM_DIR="%t/env_gitbom_dir" ld.lld %t/gitbom.o -e main --gitbom=%t/gitbom_dir -o %t/gitbom_2.exe
+# RUN: llvm-readobj -p ".bom" %t/gitbom_2.exe | FileCheck --check-prefix=GITBOM %s
 # RUN: cat %t/env_gitbom_dir/.gitbom/objects/05/ec1279f15fa8c76bab1645e5f2b2d1ba39c10a | FileCheck --check-prefix=BOM_FILE %s
+
+# RUN: rm -f %t/env_gitbom_dir/.gitbom/objects/05/ec1279f15fa8c76bab1645e5f2b2d1ba39c10a
+# RUN: env GITBOM_DIR="%t/env_gitbom_dir" ld.lld %t/gitbom.o -e main -o %t/gitbom_3.exe
+# RUN: llvm-readobj -p ".bom" %t/gitbom_3.exe | FileCheck --check-prefix=GITBOM %s
+# RUN: cat %t/env_gitbom_dir/.gitbom/objects/05/ec1279f15fa8c76bab1645e5f2b2d1ba39c10a | FileCheck --check-prefix=BOM_FILE %s
+
+# RUN: env GITBOM_DIR= ld.lld %t/gitbom.o -e main --gitbom -o gitbom_4.exe
+# RUN: llvm-readobj -p ".bom" gitbom_4.exe | FileCheck --check-prefix=GITBOM %s
+# RUN: cat .gitbom/objects/05/ec1279f15fa8c76bab1645e5f2b2d1ba39c10a | FileCheck --check-prefix=BOM_FILE %s
 
 # GITBOM: File: {{.*}}
 # GITBOM-NEXT: Format: elf64-x86-64

--- a/llvm-project/lld/test/ELF/gitbom_test.s
+++ b/llvm-project/lld/test/ELF/gitbom_test.s
@@ -7,7 +7,7 @@
 # RUN: ld.lld %t/gitbom.o -e main --gitbom=%t/gitbom_dir -o %t/gitbom.exe
 # RUN: cat %t/gitbom_dir/.gitbom/objects/05/ec1279f15fa8c76bab1645e5f2b2d1ba39c10a | FileCheck --check-prefix=BOM_FILE %s
 
-# RUN: env LLVM_GITBOM_DIR="%t/env_gitbom_dir" ld.lld %t/gitbom.o -e main --gitbom=%t/gitbom_dir -o %t/gitbom.exe
+# RUN: env GITBOM_DIR="%t/env_gitbom_dir" ld.lld %t/gitbom.o -e main --gitbom=%t/gitbom_dir -o %t/gitbom.exe
 # RUN: cat %t/env_gitbom_dir/.gitbom/objects/05/ec1279f15fa8c76bab1645e5f2b2d1ba39c10a | FileCheck --check-prefix=BOM_FILE %s
 
 # GITBOM: File: {{.*}}

--- a/llvm-project/lld/test/ELF/gitbom_test.s
+++ b/llvm-project/lld/test/ELF/gitbom_test.s
@@ -3,6 +3,13 @@
 # RUN: ld.lld %t/gitbom.o -e main --gitbom -o %t/gitbom.exe
 # RUN: llvm-readobj -p ".bom" %t/gitbom.exe | FileCheck --check-prefix=GITBOM %s
 # RUN: cat %t/.gitbom/objects/05/ec1279f15fa8c76bab1645e5f2b2d1ba39c10a | FileCheck --check-prefix=BOM_FILE %s
+
+# RUN: ld.lld %t/gitbom.o -e main --gitbom=%t/gitbom_dir -o %t/gitbom.exe
+# RUN: cat %t/gitbom_dir/.gitbom/objects/05/ec1279f15fa8c76bab1645e5f2b2d1ba39c10a | FileCheck --check-prefix=BOM_FILE %s
+
+# RUN: env LLVM_GITBOM_DIR="%t/env_gitbom_dir" ld.lld %t/gitbom.o -e main --gitbom=%t/gitbom_dir -o %t/gitbom.exe
+# RUN: cat %t/env_gitbom_dir/.gitbom/objects/05/ec1279f15fa8c76bab1645e5f2b2d1ba39c10a | FileCheck --check-prefix=BOM_FILE %s
+
 # GITBOM: File: {{.*}}
 # GITBOM-NEXT: Format: elf64-x86-64
 # GITBOM-NEXT: Arch: x86_64


### PR DESCRIPTION
The path to store gitbom files can now be specified in the command-line (clang's -frecord-gitbom option and lld's --gitbom option). The path can also be specified using an environment variable LLVM_GITBOM_DIR, which takes precedence over the command line options. 