### PR TITLE
Generate GitBOM data when -o option is not provided

### DIFF
--- a/llvm-project/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/llvm-project/clang/lib/Driver/ToolChains/Clang.cpp
@@ -6828,9 +6828,9 @@ void Clang::ConstructJob(Compilation &C, const JobAction &JA,
     else if (Arg *OutputOpt = Args.getLastArg(options::OPT_o)) {
       OutputPath = OutputOpt->getValue();
       llvm::sys::path::remove_filename(OutputPath);
-      if (OutputPath.str().empty())
-        OutputPath = StringRef("./");
     }
+    if (OutputPath.str().empty())
+      OutputPath = StringRef("./");
   }
   if (!OutputPath.str().empty()) {
     llvm::sys::path::append(OutputPath, ".gitbom");

--- a/llvm-project/clang/test/CodeGen/gitbom_test.c
+++ b/llvm-project/clang/test/CodeGen/gitbom_test.c
@@ -22,6 +22,11 @@
 // RUN: llvm-readelf -p ".bom" %t/gitbom_5.o | FileCheck --check-prefix=BOM_IDENTIFIER %s
 // RUN: cat %t/.gitbom/objects/50/16da29beed4d19143174ae53d5a69d5fa2afa4 | FileCheck --check-prefix=BOM_FILE_CONTENTS %s
 
+// RUN: rm -f .gitbom/objects/50/16da29beed4d19143174ae53d5a69d5fa2afa4
+// RUN: env GITBOM_DIR= %clang -c -frecord-gitbom %S/Inputs/gitbom.c -I%S/Inputs/gitbom.h
+// RUN: llvm-readelf -p ".bom" gitbom.o | FileCheck --check-prefix=BOM_IDENTIFIER %s
+// RUN: cat .gitbom/objects/50/16da29beed4d19143174ae53d5a69d5fa2afa4 | FileCheck --check-prefix=BOM_FILE_CONTENTS %s
+
 // BOM_IDENTIFIER: [     0] P..)..M..1t.S..._...
 // BOM_FILE_CONTENTS: blob 6e00bf3ad31d164ffc9a1a64a377857607a24085
 // BOM_FILE_CONTENTS: blob c7184931bb3205d7eff290af1860fbed5f963fb5


### PR DESCRIPTION
Signed-off-by: Bharathi Seshadri <bharathi.seshadri@gmail.com>

GitBOM dir wasn't populated correctly when -o option was not passed to the compilation command. Due to this the gitbom document and .bom section weren't created in this case. This patch fixes this.