### PR TITLE
LLD: Fix regression in hash generation when linking multiple objects

### DIFF
--- a/llvm-project/lld/ELF/SyntheticSections.cpp
+++ b/llvm-project/lld/ELF/SyntheticSections.cpp
@@ -147,11 +147,11 @@ static std::string convertToHex(StringRef Input) {
 }
 
 static void genArtifactIds(FileHashBomMap &BomMap) {
-  llvm::SHA1 SHA1_Hash;
-  llvm::SHA256 SHA256_Hash;
   struct Gitbom bomData;
 
   for (StringRef path : config->dependencyFiles) {
+    llvm::SHA1 SHA1_Hash;
+    llvm::SHA256 SHA256_Hash;
     llvm::ErrorOr<std::unique_ptr<llvm::MemoryBuffer>> fileBuf =
         llvm::MemoryBuffer::getFile(path, /*IsText=*/true);
     if (!fileBuf) {

--- a/llvm-project/lld/test/ELF/Inputs/gitbom_add.s
+++ b/llvm-project/lld/test/ELF/Inputs/gitbom_add.s
@@ -1,0 +1,41 @@
+	.text
+	.file	"gitbom.c"
+	.globl	add                             # -- Begin function add
+	.p2align	4, 0x90
+	.type	add,@function
+add:                                    # @add
+	.cfi_startproc
+# %bb.0:
+	pushq	%rbp
+	.cfi_def_cfa_offset 16
+	.cfi_offset %rbp, -16
+	movq	%rsp, %rbp
+	.cfi_def_cfa_register %rbp
+	movl	%edi, -4(%rbp)
+	movl	%esi, -8(%rbp)
+	movl	-4(%rbp), %eax
+	addl	-8(%rbp), %eax
+	popq	%rbp
+	.cfi_def_cfa %rsp, 8
+	retq
+.Lfunc_end0:
+	.size	add, .Lfunc_end0-add
+	.cfi_endproc
+                                        # -- End function
+	.ident	"clang version 14.0.1 (git@github.com:git-bom/llvm-gitbom.git 9ba9ecef3e21d8da274e1d49324c137d0ad51a49)"
+	.section	.note.gitbom,"M",@note,1
+	.long	7
+	.long	20
+	.long	1
+	.ascii	"GITBOM"
+	.zero	2
+	.ascii	"j\314\230\260t\226!\312\347\341\231\320k\344\2306\320\013\225\356"
+	.long	7
+	.long	32
+	.long	2
+	.ascii	"GITBOM"
+	.zero	2
+	.ascii	"\265'C\337^\332\320\361&\200\346\301\027-\371\215_\022\330\311\035\bh\247.'~tA\206\214\022"
+	.text
+	.section	".note.GNU-stack","",@progbits
+	.addrsig

--- a/llvm-project/lld/test/ELF/Inputs/gitbom_main.s
+++ b/llvm-project/lld/test/ELF/Inputs/gitbom_main.s
@@ -1,0 +1,46 @@
+	.text
+	.file	"gitbom_main.c"
+	.globl	main                            # -- Begin function main
+	.p2align	4, 0x90
+	.type	main,@function
+main:                                   # @main
+	.cfi_startproc
+# %bb.0:
+	pushq	%rbp
+	.cfi_def_cfa_offset 16
+	.cfi_offset %rbp, -16
+	movq	%rsp, %rbp
+	.cfi_def_cfa_register %rbp
+	subq	$16, %rsp
+	movl	$0, -4(%rbp)
+	movl	$2, %edi
+	movl	$10, %esi
+	callq	add
+	movl	%eax, -8(%rbp)
+	xorl	%eax, %eax
+	addq	$16, %rsp
+	popq	%rbp
+	.cfi_def_cfa %rsp, 8
+	retq
+.Lfunc_end0:
+	.size	main, .Lfunc_end0-main
+	.cfi_endproc
+                                        # -- End function
+	.ident	"clang version 14.0.1 (git@github.com:git-bom/llvm-gitbom.git 9ba9ecef3e21d8da274e1d49324c137d0ad51a49)"
+	.section	.note.gitbom,"M",@note,1
+	.long	7
+	.long	20
+	.long	1
+	.ascii	"GITBOM"
+	.zero	2
+	.ascii	"&\311\231-;\037a\r \254\315\366w\353S\317E\265T\322"
+	.long	7
+	.long	32
+	.long	2
+	.ascii	"GITBOM"
+	.zero	2
+	.ascii	"\260\020K\004`w\377\2400\316\267\025\356\335`\230\177\263O_]\264\341\t\350\243^\321\361\365\3428"
+	.text
+	.section	".note.GNU-stack","",@progbits
+	.addrsig
+	.addrsig_sym add

--- a/llvm-project/lld/test/ELF/gitbom_test_2.s
+++ b/llvm-project/lld/test/ELF/gitbom_test_2.s
@@ -1,0 +1,22 @@
+# RUN: rm -rf %t && mkdir %t
+# RUN: llvm-mc -filetype=obj -triple=x86_64-pc-linux %S/Inputs/gitbom_add.s -o %t/gitbom_add.o
+# RUN: llvm-mc -filetype=obj -triple=x86_64-pc-linux %S/Inputs/gitbom_main.s -o %t/gitbom_main.o
+# RUN: ld.lld %t/gitbom_add.o %t/gitbom_main.o -e main --gitbom -o %t/gitbom_add.exe
+# RUN: llvm-readelf -n %t/gitbom_add.exe | FileCheck --check-prefix=BOM_NOTE_SECTION %s
+# RUN: cat %t/.gitbom/objects/sha1/50/df005d1723744ae1a72c230ab5966249e60e73 | FileCheck --check-prefix=BOM_FILE_SHA1 %s
+# RUN: cat %t/.gitbom/objects/sha256/30/24033b51ef1520fc9c9caccb0e6a892cdb7c4f56c3569c5d703b4b7bd6e640 | FileCheck --check-prefix=BOM_FILE_SHA256 %s
+
+# BOM_FILE_SHA1: gitoid blob sha1
+# BOM_FILE_SHA1: blob 51edef04a9699ecfd756dc6d2ae9e552a394d8b2 bom 6acc98b0749621cae7e199d06be49836d00b95ee
+# BOM_FILE_SHA1: blob 64f63d5ad317e8b765b9d60e2da450d391965507 bom 26c9992d3b1f610d20accdf677eb53cf45b554d2
+
+# BOM_FILE_SHA256: gitoid blob sha256
+# BOM_FILE_SHA256: blob 302148db2b9cd7b35b8e1f61c8c0b198e21bb5353ecd01f8cb1d9814d6697e51 bom b0104b046077ffa030ceb715eedd60987fb34f5f5db4e109e8a35ed1f1f5e238
+# BOM_FILE_SHA256: blob 8e1bc85a80973ac359ceb126d35864aeef2db5066dd16f5d5e269a0e78e71333 bom b52743df5edad0f12680e6c1172df98d5f12d8c91d0868a72e277e7441868c12
+
+# BOM_NOTE_SECTION: Displaying notes found in: .note.gitbom
+# BOM_NOTE_SECTION-NEXT: Owner                Data size        Description
+# BOM_NOTE_SECTION-NEXT: 0x00000014       NT_GITBOM (SHA1 GITOID)
+# BOM_NOTE_SECTION-NEXT: SHA1 GitOID: 50df005d1723744ae1a72c230ab5966249e60e73
+# BOM_NOTE_SECTION-NEXT: 0x00000020       NT_GITBOM (SHA256 GITOID)
+# BOM_NOTE_SECTION-NEXT: SHA256 GitOID: 3024033b51ef1520fc9c9caccb0e6a892cdb7c4f56c3569c5d703b4b7bd6e640


### PR DESCRIPTION
Fixed a bug that was introduced after some code refactoring in d31061b1518508395d46882f10da5b7bce7ed191.

Also added a test case for linking multiple objects that exposed the bug.

Signed-off-by: Bharathi Seshadri <bharathi.seshadri@gmail.com>