### PR TITLE
Fix naming of subdir as per Omnibor spec

### DIFF
--- a/llvm-project/clang/lib/CodeGen/CodeGenModule.cpp
+++ b/llvm-project/clang/lib/CodeGen/CodeGenModule.cpp
@@ -6452,7 +6452,7 @@ static std::string ComputeSHA1OmniBorData(CodeGenModule &CGM,
   gitoid = Result.str();
 
   SmallString<128> gitoidPath(CGM.getCodeGenOpts().RecordOmniBor);
-  llvm::sys::path::append(gitoidPath, "sha1");
+  llvm::sys::path::append(gitoidPath, "gitoid_blob_sha1");
   llvm::sys::path::append(gitoidPath, gitoidHex.substr(0, 2));
   std::error_code EC;
   EC = llvm::sys::fs::create_directories(gitoidPath, true);
@@ -6496,7 +6496,7 @@ static std::string ComputeSHA256OmniBorData(CodeGenModule &CGM,
   gitoid = Result.str();
 
   SmallString<128> gitoidPath(CGM.getCodeGenOpts().RecordOmniBor);
-  llvm::sys::path::append(gitoidPath, "sha256");
+  llvm::sys::path::append(gitoidPath, "gitoid_blob_sha256");
   llvm::sys::path::append(gitoidPath, gitoidHex.substr(0, 2));
   std::error_code EC;
   EC = llvm::sys::fs::create_directories(gitoidPath, true);

--- a/llvm-project/clang/test/CodeGen/omnibor_test.c
+++ b/llvm-project/clang/test/CodeGen/omnibor_test.c
@@ -2,36 +2,36 @@
 
 // RUN: %clang -c -frecord-omnibor -o %t/omnibor_1.o %S/Inputs/omnibor.c -I%S/Inputs/omnibor.h
 // RUN: llvm-readelf -n %t/omnibor_1.o | FileCheck --check-prefix=BOM_NOTE_SECTION %s
-// RUN: cat %t/objects/sha1/0b/e9b91c3e456c910b32afc862ffd073b7c61d5f | FileCheck --check-prefix=BOM_FILE_SHA1_CONTENTS %s
-// RUN: cat %t/objects/sha256/58/ed318e337ad6260f471c086e9c9985543c5fbd507c3b44924f5af37bd0ea96 | FileCheck --check-prefix=BOM_FILE_SHA256_CONTENTS %s
+// RUN: cat %t/objects/gitoid_blob_sha1/0b/e9b91c3e456c910b32afc862ffd073b7c61d5f | FileCheck --check-prefix=BOM_FILE_SHA1_CONTENTS %s
+// RUN: cat %t/objects/gitoid_blob_sha256/58/ed318e337ad6260f471c086e9c9985543c5fbd507c3b44924f5af37bd0ea96 | FileCheck --check-prefix=BOM_FILE_SHA256_CONTENTS %s
 
 // RUN: %clang -c -frecord-omnibor=%t/omnibordir -o %t/omnibor_2.o %S/Inputs/omnibor.c -I%S/Inputs/omnibor.h
 // RUN: llvm-readelf -n %t/omnibor_2.o | FileCheck --check-prefix=BOM_NOTE_SECTION %s
-// RUN: cat %t/omnibordir/objects/sha1/0b/e9b91c3e456c910b32afc862ffd073b7c61d5f | FileCheck --check-prefix=BOM_FILE_SHA1_CONTENTS %s
-// RUN: cat %t/objects/sha256/58/ed318e337ad6260f471c086e9c9985543c5fbd507c3b44924f5af37bd0ea96 | FileCheck --check-prefix=BOM_FILE_SHA256_CONTENTS %s
+// RUN: cat %t/omnibordir/objects/gitoid_blob_sha1/0b/e9b91c3e456c910b32afc862ffd073b7c61d5f | FileCheck --check-prefix=BOM_FILE_SHA1_CONTENTS %s
+// RUN: cat %t/objects/gitoid_blob_sha256/58/ed318e337ad6260f471c086e9c9985543c5fbd507c3b44924f5af37bd0ea96 | FileCheck --check-prefix=BOM_FILE_SHA256_CONTENTS %s
 
 // RUN: env OMNIBOR_DIR="%t/env_omnibor_dir" %clang -c -frecord-omnibor=%t/omnibordir -o %t/omnibor_3.o %S/Inputs/omnibor.c -I%S/Inputs/omnibor.h
 // RUN: llvm-readelf -n %t/omnibor_3.o | FileCheck --check-prefix=BOM_NOTE_SECTION %s
-// RUN: cat %t/env_omnibor_dir/objects/sha1/0b/e9b91c3e456c910b32afc862ffd073b7c61d5f | FileCheck --check-prefix=BOM_FILE_SHA1_CONTENTS %s
-// RUN: cat %t/env_omnibor_dir/objects/sha256/58/ed318e337ad6260f471c086e9c9985543c5fbd507c3b44924f5af37bd0ea96 | FileCheck --check-prefix=BOM_FILE_SHA256_CONTENTS %s
+// RUN: cat %t/env_omnibor_dir/objects/gitoid_blob_sha1/0b/e9b91c3e456c910b32afc862ffd073b7c61d5f | FileCheck --check-prefix=BOM_FILE_SHA1_CONTENTS %s
+// RUN: cat %t/env_omnibor_dir/objects/gitoid_blob_sha256/58/ed318e337ad6260f471c086e9c9985543c5fbd507c3b44924f5af37bd0ea96 | FileCheck --check-prefix=BOM_FILE_SHA256_CONTENTS %s
 
-// RUN: rm -f %t/env_omnibor_dir/objects/sha1/63/87876e9c6f258ef88e7c81b9e1c41f14c397d1
+// RUN: rm -f %t/env_omnibor_dir/objects/gitoid_blob_sha1/63/87876e9c6f258ef88e7c81b9e1c41f14c397d1
 // RUN: env OMNIBOR_DIR="%t/env_omnibor_dir" %clang -c -o %t/omnibor_4.o %S/Inputs/omnibor.c -I%S/Inputs/omnibor.h
 // RUN: llvm-readelf -n %t/omnibor_4.o | FileCheck --check-prefix=BOM_NOTE_SECTION %s
-// RUN: cat %t/env_omnibor_dir/objects/sha1/0b/e9b91c3e456c910b32afc862ffd073b7c61d5f | FileCheck --check-prefix=BOM_FILE_SHA1_CONTENTS %s
-// RUN: cat %t/objects/sha256/58/ed318e337ad6260f471c086e9c9985543c5fbd507c3b44924f5af37bd0ea96 | FileCheck --check-prefix=BOM_FILE_SHA256_CONTENTS %s
+// RUN: cat %t/env_omnibor_dir/objects/gitoid_blob_sha1/0b/e9b91c3e456c910b32afc862ffd073b7c61d5f | FileCheck --check-prefix=BOM_FILE_SHA1_CONTENTS %s
+// RUN: cat %t/objects/gitoid_blob_sha256/58/ed318e337ad6260f471c086e9c9985543c5fbd507c3b44924f5af37bd0ea96 | FileCheck --check-prefix=BOM_FILE_SHA256_CONTENTS %s
 
-// RUN: rm -f %t/objects/sha1/0b/e9b91c3e456c910b32afc862ffd073b7c61d5f
+// RUN: rm -f %t/objects/gitoid_blob_sha1/0b/e9b91c3e456c910b32afc862ffd073b7c61d5f
 // RUN: env OMNIBOR_DIR= %clang -c -frecord-omnibor -o %t/omnibor_5.o %S/Inputs/omnibor.c -I%S/Inputs/omnibor.h
 // RUN: llvm-readelf -n %t/omnibor_5.o | FileCheck --check-prefix=BOM_NOTE_SECTION %s
-// RUN: cat %t/objects/sha1/0b/e9b91c3e456c910b32afc862ffd073b7c61d5f | FileCheck --check-prefix=BOM_FILE_SHA1_CONTENTS %s
-// RUN: cat %t/objects/sha256/58/ed318e337ad6260f471c086e9c9985543c5fbd507c3b44924f5af37bd0ea96 | FileCheck --check-prefix=BOM_FILE_SHA256_CONTENTS %s
+// RUN: cat %t/objects/gitoid_blob_sha1/0b/e9b91c3e456c910b32afc862ffd073b7c61d5f | FileCheck --check-prefix=BOM_FILE_SHA1_CONTENTS %s
+// RUN: cat %t/objects/gitoid_blob_sha256/58/ed318e337ad6260f471c086e9c9985543c5fbd507c3b44924f5af37bd0ea96 | FileCheck --check-prefix=BOM_FILE_SHA256_CONTENTS %s
 
-// RUN: rm -f objects/sha1/0b/e9b91c3e456c910b32afc862ffd073b7c61d5f
+// RUN: rm -f objects/gitoid_blob_sha1/0b/e9b91c3e456c910b32afc862ffd073b7c61d5f
 // RUN: env OMNIBOR_DIR= %clang -c -frecord-omnibor %S/Inputs/omnibor.c -I%S/Inputs/omnibor.h
 // RUN: llvm-readelf -n omnibor.o | FileCheck --check-prefix=BOM_NOTE_SECTION %s
-// RUN: cat objects/sha1/0b/e9b91c3e456c910b32afc862ffd073b7c61d5f | FileCheck --check-prefix=BOM_FILE_SHA1_CONTENTS %s
-// RUN: cat %t/objects/sha256/58/ed318e337ad6260f471c086e9c9985543c5fbd507c3b44924f5af37bd0ea96 | FileCheck --check-prefix=BOM_FILE_SHA256_CONTENTS %s
+// RUN: cat objects/gitoid_blob_sha1/0b/e9b91c3e456c910b32afc862ffd073b7c61d5f | FileCheck --check-prefix=BOM_FILE_SHA1_CONTENTS %s
+// RUN: cat %t/objects/gitoid_blob_sha256/58/ed318e337ad6260f471c086e9c9985543c5fbd507c3b44924f5af37bd0ea96 | FileCheck --check-prefix=BOM_FILE_SHA256_CONTENTS %s
 
 // BOM_NOTE_SECTION: Displaying notes found in: .note.omnibor
 // BOM_NOTE_SECTION: Owner                Data size        Description

--- a/llvm-project/clang/test/CodeGen/omnibor_test_MD.c
+++ b/llvm-project/clang/test/CodeGen/omnibor_test_MD.c
@@ -1,8 +1,8 @@
 // RUN: rm -rf %t && mkdir %t
 // RUN: %clang -c -frecord-omnibor -MD -o %t/omnibor.o %S/Inputs/omnibor.c -I%S/Inputs/omnibor.h
 // RUN: llvm-readelf -n %t/omnibor.o | FileCheck --check-prefix=BOM_NOTE %s
-// RUN: cat %t/objects/sha1/0b/e9b91c3e456c910b32afc862ffd073b7c61d5f | FileCheck --check-prefix=BOM_FILE_SHA1_CONTENTS %s
-// RUN: cat %t/objects/sha256/58/ed318e337ad6260f471c086e9c9985543c5fbd507c3b44924f5af37bd0ea96 | FileCheck --check-prefix=BOM_FILE_SHA256_CONTENTS %s
+// RUN: cat %t/objects/gitoid_blob_sha1/0b/e9b91c3e456c910b32afc862ffd073b7c61d5f | FileCheck --check-prefix=BOM_FILE_SHA1_CONTENTS %s
+// RUN: cat %t/objects/gitoid_blob_sha256/58/ed318e337ad6260f471c086e9c9985543c5fbd507c3b44924f5af37bd0ea96 | FileCheck --check-prefix=BOM_FILE_SHA256_CONTENTS %s
 // BOM_FILE_SHA1_CONTENTS: gitoid:blob:sha1
 // BOM_FILE_SHA1_CONTENTS: blob 078dc8b54dc17e60dfe9235ebe825cd810869c26
 // BOM_FILE_SHA1_CONTENTS: blob c7184931bb3205d7eff290af1860fbed5f963fb5

--- a/llvm-project/lld/ELF/SyntheticSections.cpp
+++ b/llvm-project/lld/ELF/SyntheticSections.cpp
@@ -204,7 +204,7 @@ static std::string createSHA1_BomFile(FileHashBomMap &BomMap) {
 
   SmallString<128> gitOidPath;
   gitOidPath = StringRef(config->OmniBorDir);
-  llvm::sys::path::append(gitOidPath, "sha1");
+  llvm::sys::path::append(gitOidPath, "gitoid_blob_sha1");
   llvm::sys::path::append(gitOidPath, gitOid.substr(0, 2));
   std::error_code EC;
   EC = llvm::sys::fs::create_directories(gitOidPath, true);
@@ -248,7 +248,7 @@ static std::string createSHA256_BomFile(FileHashBomMap &BomMap) {
 
   SmallString<128> gitOidPath;
   gitOidPath = StringRef(config->OmniBorDir);
-  llvm::sys::path::append(gitOidPath, "sha256");
+  llvm::sys::path::append(gitOidPath, "gitoid_blob_sha256");
   llvm::sys::path::append(gitOidPath, gitOid.substr(0, 2));
   std::error_code EC;
   EC = llvm::sys::fs::create_directories(gitOidPath, true);

--- a/llvm-project/lld/test/ELF/omnibor_test.s
+++ b/llvm-project/lld/test/ELF/omnibor_test.s
@@ -2,26 +2,26 @@
 # RUN: llvm-mc -filetype=obj -triple=x86_64-pc-linux %S/Inputs/omnibor.s -o %t/omnibor.o
 # RUN: ld.lld %t/omnibor.o -e main --omnibor -o %t/omnibor.exe
 # RUN: llvm-readelf -n %t/omnibor.exe | FileCheck --check-prefix=BOM_NOTE_SECTION %s
-# RUN: cat %t/objects/sha1/3f/f57d57064dff16633a6e3acaaa08195b9073d5 | FileCheck --check-prefix=BOM_FILE_SHA1 %s
-# RUN: cat %t/objects/sha256/b3/949098052e5a6f9e43630ff1021970518ff78b4a6e983cc6602a8f1656a6c0 | FileCheck --check-prefix=BOM_FILE_SHA256 %s
+# RUN: cat %t/objects/gitoid_blob_sha1/3f/f57d57064dff16633a6e3acaaa08195b9073d5 | FileCheck --check-prefix=BOM_FILE_SHA1 %s
+# RUN: cat %t/objects/gitoid_blob_sha256/b3/949098052e5a6f9e43630ff1021970518ff78b4a6e983cc6602a8f1656a6c0 | FileCheck --check-prefix=BOM_FILE_SHA256 %s
 
 # RUN: rm -rf %t/objects
 # RUN: ld.lld %t/omnibor.o -e main --omnibor=%t/omnibor_dir -o %t/omnibor_1.exe
 # RUN: llvm-readelf -n %t/omnibor_1.exe | FileCheck --check-prefix=BOM_NOTE_SECTION %s
-# RUN: cat %t/omnibor_dir/objects/sha1/3f/f57d57064dff16633a6e3acaaa08195b9073d5 | FileCheck --check-prefix=BOM_FILE_SHA1 %s
-# RUN: cat %t/omnibor_dir/objects/sha256/b3/949098052e5a6f9e43630ff1021970518ff78b4a6e983cc6602a8f1656a6c0 | FileCheck --check-prefix=BOM_FILE_SHA256 %s
+# RUN: cat %t/omnibor_dir/objects/gitoid_blob_sha1/3f/f57d57064dff16633a6e3acaaa08195b9073d5 | FileCheck --check-prefix=BOM_FILE_SHA1 %s
+# RUN: cat %t/omnibor_dir/objects/gitoid_blob_sha256/b3/949098052e5a6f9e43630ff1021970518ff78b4a6e983cc6602a8f1656a6c0 | FileCheck --check-prefix=BOM_FILE_SHA256 %s
 
 # RUN: rm -rf %t/env_omnibor_dir/objects
 # RUN: env OMNIBOR_DIR="%t/env_omnibor_dir" ld.lld %t/omnibor.o -e main --omnibor=%t/omnibor_dir -o %t/omnibor_2.exe
 # RUN: llvm-readelf -n %t/omnibor_2.exe | FileCheck --check-prefix=BOM_NOTE_SECTION %s
-# RUN: cat %t/env_omnibor_dir/objects/sha1/3f/f57d57064dff16633a6e3acaaa08195b9073d5 | FileCheck --check-prefix=BOM_FILE_SHA1 %s
-# RUN: cat %t/env_omnibor_dir/objects/sha256/b3/949098052e5a6f9e43630ff1021970518ff78b4a6e983cc6602a8f1656a6c0 | FileCheck --check-prefix=BOM_FILE_SHA256 %s
+# RUN: cat %t/env_omnibor_dir/objects/gitoid_blob_sha1/3f/f57d57064dff16633a6e3acaaa08195b9073d5 | FileCheck --check-prefix=BOM_FILE_SHA1 %s
+# RUN: cat %t/env_omnibor_dir/objects/gitoid_blob_sha256/b3/949098052e5a6f9e43630ff1021970518ff78b4a6e983cc6602a8f1656a6c0 | FileCheck --check-prefix=BOM_FILE_SHA256 %s
 
 # RUN: rm -rf %t/env_omnibor_dir/objects/
 # RUN: env OMNIBOR_DIR="%t/env_omnibor_dir" ld.lld %t/omnibor.o -e main -o %t/omnibor_3.exe
 # RUN: llvm-readelf -n %t/omnibor_3.exe | FileCheck --check-prefix=BOM_NOTE_SECTION %s
-# RUN: cat %t/env_omnibor_dir/objects/sha1/3f/f57d57064dff16633a6e3acaaa08195b9073d5 | FileCheck --check-prefix=BOM_FILE_SHA1 %s
-# RUN: cat %t/env_omnibor_dir/objects/sha256/b3/949098052e5a6f9e43630ff1021970518ff78b4a6e983cc6602a8f1656a6c0 | FileCheck --check-prefix=BOM_FILE_SHA256 %s
+# RUN: cat %t/env_omnibor_dir/objects/gitoid_blob_sha1/3f/f57d57064dff16633a6e3acaaa08195b9073d5 | FileCheck --check-prefix=BOM_FILE_SHA1 %s
+# RUN: cat %t/env_omnibor_dir/objects/gitoid_blob_sha256/b3/949098052e5a6f9e43630ff1021970518ff78b4a6e983cc6602a8f1656a6c0 | FileCheck --check-prefix=BOM_FILE_SHA256 %s
 
 # BOM_FILE_SHA1: gitoid blob sha1
 # BOM_FILE_SHA1: blob 6d0c1c525b24d874364f03928e77467d9ed1f2bb bom 432a5d88c4eb39bb994d57eb6252864b793f5204

--- a/llvm-project/lld/test/ELF/omnibor_test_2.s
+++ b/llvm-project/lld/test/ELF/omnibor_test_2.s
@@ -3,8 +3,8 @@
 # RUN: llvm-mc -filetype=obj -triple=x86_64-pc-linux %S/Inputs/omnibor_main.s -o %t/omnibor_main.o
 # RUN: ld.lld %t/omnibor_add.o %t/omnibor_main.o -e main --omnibor -o %t/omnibor_add.exe
 # RUN: llvm-readelf -n %t/omnibor_add.exe | FileCheck --check-prefix=BOM_NOTE_SECTION %s
-# RUN: cat %t/objects/sha1/7b/5cc942363892974b8089c3fb1cc92a1f807ba1 | FileCheck --check-prefix=BOM_FILE_SHA1 %s
-# RUN: cat %t/objects/sha256/17/42972fe1ab0fe742635cd6bb9c06ef3a8f7102b7e1f9c0eaaa70bb09684a4a | FileCheck --check-prefix=BOM_FILE_SHA256 %s
+# RUN: cat %t/objects/gitoid_blob_sha1/7b/5cc942363892974b8089c3fb1cc92a1f807ba1 | FileCheck --check-prefix=BOM_FILE_SHA1 %s
+# RUN: cat %t/objects/gitoid_blob_sha256/17/42972fe1ab0fe742635cd6bb9c06ef3a8f7102b7e1f9c0eaaa70bb09684a4a | FileCheck --check-prefix=BOM_FILE_SHA256 %s
 
 # BOM_FILE_SHA1: gitoid blob sha1
 # BOM_FILE_SHA1: blob 6d1df76ef597632db1f2547700f85fb4594dcf52 bom 6acc98b0749621cae7e199d06be49836d00b95ee


### PR DESCRIPTION
Signed-off-by: Bharathi Seshadri <bharathi.seshadri@gmail.com>

Change the name of subdirectory where omnibor data is stored from $OMNIBOR_DIR/objects/sha1 to $OMNIBOR_DIR/objects/gitoid_blob_sha1 (similar change for sha256).