### PR TITLE
Add OmniBOR support for assembler

### DIFF
--- a/llvm-project/clang/include/clang/Driver/Options.td
+++ b/llvm-project/clang/include/clang/Driver/Options.td
@@ -6024,6 +6024,8 @@ def n : Flag<["-"], "n">,
 // Frontend Options
 def filetype : Separate<["-"], "filetype">,
     HelpText<"Specify the output file type ('asm', 'null', or 'obj')">;
+def omnibor_as : Separate<["-"], "omnibor-as">,
+    HelpText<"Generate OmniBOR data in the given path">;
 
 // Transliterate Options
 def output_asm_variant : Separate<["-"], "output-asm-variant">,

--- a/llvm-project/clang/include/clang/Frontend/Utils.h
+++ b/llvm-project/clang/include/clang/Frontend/Utils.h
@@ -104,7 +104,7 @@ private:
   std::shared_ptr<std::vector<std::string>> BomDependencies;
 };
 
-// Duplicating FileGenerator for generating BomDependenciesas the semantics
+// Duplicating FileGenerator for generating BomDependencies as the semantics
 // of BomDependencies and -MD could differ. For example, system headers are
 // always treated as a dependency for omnibor.
 class BomDependencyGenerator : public DependencyCollector {

--- a/llvm-project/clang/test/Driver/Inputs/omnibor/no-omnibor.s
+++ b/llvm-project/clang/test/Driver/Inputs/omnibor/no-omnibor.s
@@ -1,0 +1,37 @@
+	.text
+	.file	"hello.c"
+	.globl	main                            # -- Begin function main
+	.p2align	4, 0x90
+	.type	main,@function
+main:                                   # @main
+	.cfi_startproc
+# %bb.0:
+	pushq	%rbp
+	.cfi_def_cfa_offset 16
+	.cfi_offset %rbp, -16
+	movq	%rsp, %rbp
+	.cfi_def_cfa_register %rbp
+	subq	$16, %rsp
+	movl	$0, -4(%rbp)
+	movabsq	$.L.str, %rdi
+	movb	$0, %al
+	callq	printf
+	xorl	%eax, %eax
+	addq	$16, %rsp
+	popq	%rbp
+	.cfi_def_cfa %rsp, 8
+	retq
+.Lfunc_end0:
+	.size	main, .Lfunc_end0-main
+	.cfi_endproc
+                                        # -- End function
+	.type	.L.str,@object                  # @.str
+	.section	.rodata.str1.1,"aMS",@progbits,1
+.L.str:
+	.asciz	"\n hello"
+	.size	.L.str, 8
+
+	.ident	"clang version 14.0.1 (llvm-omnibor.git 7f56c2d1aa0242753f109f02b84c68190a48f2a8)"
+	.section	".note.GNU-stack","",@progbits
+	.addrsig
+	.addrsig_sym printf

--- a/llvm-project/clang/test/Driver/Inputs/omnibor/omnibor.s
+++ b/llvm-project/clang/test/Driver/Inputs/omnibor/omnibor.s
@@ -1,0 +1,51 @@
+	.text
+	.file	"hello.c"
+	.globl	main                            # -- Begin function main
+	.p2align	4, 0x90
+	.type	main,@function
+main:                                   # @main
+	.cfi_startproc
+# %bb.0:
+	pushq	%rbp
+	.cfi_def_cfa_offset 16
+	.cfi_offset %rbp, -16
+	movq	%rsp, %rbp
+	.cfi_def_cfa_register %rbp
+	subq	$16, %rsp
+	movl	$0, -4(%rbp)
+	movabsq	$.L.str, %rdi
+	movb	$0, %al
+	callq	printf
+	xorl	%eax, %eax
+	addq	$16, %rsp
+	popq	%rbp
+	.cfi_def_cfa %rsp, 8
+	retq
+.Lfunc_end0:
+	.size	main, .Lfunc_end0-main
+	.cfi_endproc
+                                        # -- End function
+	.type	.L.str,@object                  # @.str
+	.section	.rodata.str1.1,"aMS",@progbits,1
+.L.str:
+	.asciz	"\n hello"
+	.size	.L.str, 8
+
+	.ident	"clang version 14.0.1 (llvm-omnibor.git 7f56c2d1aa0242753f109f02b84c68190a48f2a8)"
+	.section	.note.omnibor,"a",@note
+	.long	8
+	.long	20
+	.long	1
+	.ascii	"OMNIBOR"
+	.zero	1
+	.ascii	"Km\311>Q\241\267Po@\364\b'^\221\254\375\030\r,"
+	.long	8
+	.long	32
+	.long	2
+	.ascii	"OMNIBOR"
+	.zero	1
+	.ascii	"[\310\211iP\317\003\212<\225\223\261<b%{\242\350NN\210\005\221p\217NC\005\277\037\027\315"
+	.section	.rodata.str1.1,"aMS",@progbits,1
+	.section	".note.GNU-stack","",@progbits
+	.addrsig
+	.addrsig_sym printf

--- a/llvm-project/clang/test/Driver/clang_f_opts.c
+++ b/llvm-project/clang/test/Driver/clang_f_opts.c
@@ -554,8 +554,8 @@
 // CHECK-RECORD-GCC-SWITCHES: "-record-command-line"
 // CHECK-NO-RECORD-GCC-SWITCHES-NOT: "-record-command-line"
 // CHECK-RECORD-GCC-SWITCHES-ERROR: error: unsupported option '-frecord-command-line' for target
-// CHECK-RECORD-GITBOM: "-record-gitbom"
-// CHECK-RECORD-GITBOM-NOT: "-record-gitbom"
+// CHECK-RECORD-OMNIBOR: "-record-omnibor"
+// CHECK-NO-RECORD-OMNIBOR-NOT: "-record-omnibor"
 // Test when clang is in a path containing a space.
 // The initial `rm` is a workaround for https://openradar.appspot.com/FB8914243
 // (Scenario: Run tests once, `clang` gets copied and run at new location and signature
@@ -570,8 +570,8 @@
 // Clean up copy of large binary copied into temp directory to avoid bloat.
 // RUN: rm -f "%t.r/with spaces/clang" || true
 
-// RUN: %clang -### -S -target x86_64-unknown-linux -frecord-gitbom %s 2>&1 | FileCheck -check-prefix=CHECK-RECORD-GITBOM %s
-// RUN: %clang -### -S -target x86_64-unknown-linux -fno-record-gitbom %s 2>&1 | FileCheck -check-prefix=CHECK-NO-RECORD-GITBOM %s
+// RUN: %clang -### -S -target x86_64-unknown-linux -frecord-omnibor %s 2>&1 | FileCheck -check-prefix=CHECK-RECORD-OMNIBOR %s
+// RUN: %clang -### -S -target x86_64-unknown-linux -fno-record-omnibor %s 2>&1 | FileCheck -check-prefix=CHECK-NO-RECORD-OMNIBOR %s
 // RUN: %clang -### -S -ftrivial-auto-var-init=uninitialized %s 2>&1 | FileCheck -check-prefix=CHECK-TRIVIAL-UNINIT %s
 // RUN: %clang -### -S -ftrivial-auto-var-init=pattern %s 2>&1 | FileCheck -check-prefix=CHECK-TRIVIAL-PATTERN %s
 // RUN: %clang -### -S -ftrivial-auto-var-init=zero -enable-trivial-auto-var-init-zero-knowing-it-will-be-removed-from-clang %s 2>&1 | FileCheck -check-prefix=CHECK-TRIVIAL-ZERO-GOOD %s

--- a/llvm-project/clang/test/Driver/omnibor-test.s
+++ b/llvm-project/clang/test/Driver/omnibor-test.s
@@ -1,0 +1,60 @@
+# RUN: rm -rf %t && mkdir %t
+# RUN: env OMNIBOR_DIR="%t/env_omnibor_dir" %clang -c -target x86_64-linux-gnu %S/Inputs/omnibor/omnibor.s -o %t/omnibor.o
+# RUN: llvm-readelf -n %t/omnibor.o | FileCheck --check-prefix=CHECK-OMNIBOR-1 %s
+# RUN: cat %t/env_omnibor_dir/objects/gitoid_blob_sha1/70/a1f821592cc68919c7d2aebbad02c58dfb5d09 | FileCheck --check-prefix=OMNIBOR-1-SHA1-NOTE %s
+# RUN: cat %t/env_omnibor_dir/objects/gitoid_blob_sha256/1c/3b786338c344b1a094d7df2d6c2dbdbecc9eb3987004a173cd1c07dd108faf | FileCheck --check-prefix=OMNIBOR-1-SHA256-NOTE %s
+
+# RUN: %clang -c -target x86_64-linux-gnu %S/Inputs/omnibor/omnibor.s -o %t/omnibor.o
+# RUN: llvm-readelf -n %t/omnibor.o | FileCheck --allow-empty --check-prefix=CHECK-NO-OMNIBOR %s
+
+# RUN: rm -rf %t/env_omnibor_dir
+# RUN: env OMNIBOR_DIR="%t/env_omnibor_dir" %clang -c -target x86_64-linux-gnu %S/Inputs/omnibor/no-omnibor.s -o %t/no-omnibor.o
+# RUN: llvm-readelf -n %t/no-omnibor.o | FileCheck --check-prefix=CHECK-OMNIBOR-2 %s
+# RUN: cat %t/env_omnibor_dir/objects/gitoid_blob_sha1/e1/c058d0ab49e12b2a0063be9b62efea9f2453c0 | FileCheck --check-prefix=OMNIBOR-2-SHA1-NOTE %s
+# RUN: cat %t/env_omnibor_dir/objects/gitoid_blob_sha256/cd/ae8735776aa8f7e20531f631dd73affbd992dfc7d464ec2586760edd071893 | FileCheck --check-prefix=OMNIBOR-2-SHA256-NOTE %s
+
+# RUN: %clang -c -target x86_64-linux-gnu %S/Inputs/omnibor/no-omnibor.s -o %t/no-omnibor.o
+# RUN: llvm-readelf -n %t/no-omnibor.o | FileCheck --allow-empty --check-prefix=CHECK-NO-OMNIBOR %s
+
+# RUN: rm -rf %t/env_omnibor_dir %t/objects
+# RUN: %clang -cc1as -filetype obj -triple x86_64-linux-gnu %S/Inputs/omnibor/omnibor.s -o %t/omnibor.o
+# RUN: llvm-readelf -n %t/omnibor.o | FileCheck --allow-empty --check-prefix=CHECK-NO-OMNIBOR %s
+
+# RUN: %clang -cc1as -filetype obj -omnibor-as %t -triple x86_64-linux-gnu %S/Inputs/omnibor/omnibor.s -o %t/omnibor.o
+# RUN: llvm-readelf -n %t/omnibor.o | FileCheck --allow-empty --check-prefix=CHECK-OMNIBOR-1 %s
+# RUN: cat %t/objects/gitoid_blob_sha1/70/a1f821592cc68919c7d2aebbad02c58dfb5d09 | FileCheck --check-prefix=OMNIBOR-1-SHA1-NOTE %s
+# RUN: cat %t/objects/gitoid_blob_sha256/1c/3b786338c344b1a094d7df2d6c2dbdbecc9eb3987004a173cd1c07dd108faf | FileCheck --check-prefix=OMNIBOR-1-SHA256-NOTE %s
+
+# RUN: rm -rf %t/env_omnibor_dir
+# RUN: env OMNIBOR_DIR="%t/env_omnibor_dir" %clang -cc1as -filetype obj -triple x86_64-linux-gnu %S/Inputs/omnibor/no-omnibor.s -o %t/no-omnibor.o
+# RUN: llvm-readelf -n %t/no-omnibor.o | FileCheck --check-prefix=CHECK-OMNIBOR-2 %s
+# RUN: cat %t/env_omnibor_dir/objects/gitoid_blob_sha1/e1/c058d0ab49e12b2a0063be9b62efea9f2453c0 | FileCheck --check-prefix=OMNIBOR-2-SHA1-NOTE %s
+# RUN: cat %t/env_omnibor_dir/objects/gitoid_blob_sha256/cd/ae8735776aa8f7e20531f631dd73affbd992dfc7d464ec2586760edd071893 | FileCheck --check-prefix=OMNIBOR-2-SHA256-NOTE %s
+
+# CHECK-OMNIBOR-1: Displaying notes found in: .note.omnibor
+# CHECK-OMNIBOR-1-NEXT:  Owner                Data size        Description
+# CHECK-OMNIBOR-1-NEXT:  OMNIBOR              0x00000014       NT_GITOID_SHA1
+# CHECK-OMNIBOR-1-NEXT:  SHA1 GitOID: 70a1f821592cc68919c7d2aebbad02c58dfb5d09
+# CHECK-OMNIBOR-1-NEXT:  OMNIBOR              0x00000020       NT_GITOID_SHA256
+# CHECK-OMNIBOR-1-NEXT:  SHA256 GitOID: 1c3b786338c344b1a094d7df2d6c2dbdbecc9eb3987004a173cd1c07dd108faf
+
+# CHECK-NO-OMNIBOR-NOT: Displaying notes found in: .note.omnibor
+
+# OMNIBOR-1-SHA1-NOTE: gitoid blob sha1
+# OMNIBOR-1-SHA1-NOTE-NEXT: blob 46d7cf5af3c8e0649943db9d6ed5b248a083285a bom 4b6dc93e51a1b7506f40f408275e91acfd180d2c
+
+# OMNIBOR-1-SHA256-NOTE: gitoid blob sha256
+# OMNIBOR-1-SHA256-NOTE-NEXT: blob 46872ea9d85ac8c80f548a1718b3d2e37695f495099423f01430c20c26ba73ee bom 5bc8896950cf038a3c9593b13c62257ba2e84e4e880591708f4e4305bf1f17cd
+
+# CHECK-OMNIBOR-2: Displaying notes found in: .note.omnibor
+# CHECK-OMNIBOR-2-NEXT: Owner                Data size        Description
+# CHECK-OMNIBOR-2-NEXT: OMNIBOR              0x00000014       NT_GITOID_SHA1
+# CHECK-OMNIBOR-2-NEXT: SHA1 GitOID: e1c058d0ab49e12b2a0063be9b62efea9f2453c0
+# CHECK-OMNIBOR-2-NEXT: OMNIBOR              0x00000020       NT_GITOID_SHA256
+# CHECK-OMNIBOR-2-NEXT: SHA256 GitOID: cdae8735776aa8f7e20531f631dd73affbd992dfc7d464ec2586760edd071893
+
+# OMNIBOR-2-SHA1-NOTE: gitoid blob sha1
+# OMNIBOR-2-SHA1-NOTE-NEXT: blob 52ebed6cf07d7ca81b88d47e905cb3c732e8ff3f
+
+# OMNIBOR-2-SHA256-NOTE: gitoid blob sha256
+# OMNIBOR-2-SHA256-NOTE-NEXT: 00b7792291a7818372031121c4556f3ac89fb7350be06423681604b7fb93873e

--- a/llvm-project/clang/tools/driver/cc1as_main.cpp
+++ b/llvm-project/clang/tools/driver/cc1as_main.cpp
@@ -115,6 +115,7 @@ struct AssemblerInvocation {
     FT_Obj   ///< Object file output.
   };
   FileType OutputType;
+  std::string OmniborAs;
   unsigned ShowHelp : 1;
   unsigned ShowVersion : 1;
 
@@ -280,6 +281,9 @@ bool AssemblerInvocation::CreateFromArgs(AssemblerInvocation &Opts,
     } else
       Opts.OutputType = FileType(OutputType);
   }
+  if (Arg *A = Args.getLastArg(OPT_omnibor_as)) {
+    Opts.OmniborAs = A->getValue();
+  }
   Opts.ShowHelp = Args.hasArg(OPT_help);
   Opts.ShowVersion = Args.hasArg(OPT_version);
 
@@ -435,6 +439,12 @@ static bool ExecuteAssemblerImpl(AssemblerInvocation &Opts,
   if (Opts.GenDwarfForAssembly)
     Ctx.setGenDwarfRootFile(Opts.InputFile,
                             SrcMgr.getMemoryBuffer(BufferIndex)->getBuffer());
+
+  const char *env = ::getenv("OMNIBOR_DIR");
+  if (!Opts.OmniborAs.empty())
+    Ctx.setOmniborAs(Opts.OmniborAs);
+  else if (env)
+    Ctx.setOmniborAs(env);
 
   std::unique_ptr<MCStreamer> Str;
 

--- a/llvm-project/lld/test/ELF/omnibor_test.s
+++ b/llvm-project/lld/test/ELF/omnibor_test.s
@@ -1,37 +1,37 @@
 # RUN: rm -rf %t && mkdir %t
-# RUN: llvm-mc -filetype=obj -triple=x86_64-pc-linux %S/Inputs/omnibor.s -o %t/omnibor.o
+# RUN: llvm-mc -filetype=obj --omnibor-as=%t -triple=x86_64-pc-linux %S/Inputs/omnibor.s -o %t/omnibor.o
 # RUN: ld.lld %t/omnibor.o -e main --omnibor -o %t/omnibor.exe
 # RUN: llvm-readelf -n %t/omnibor.exe | FileCheck --check-prefix=BOM_NOTE_SECTION %s
-# RUN: cat %t/objects/gitoid_blob_sha1/3f/f57d57064dff16633a6e3acaaa08195b9073d5 | FileCheck --check-prefix=BOM_FILE_SHA1 %s
-# RUN: cat %t/objects/gitoid_blob_sha256/b3/949098052e5a6f9e43630ff1021970518ff78b4a6e983cc6602a8f1656a6c0 | FileCheck --check-prefix=BOM_FILE_SHA256 %s
+# RUN: cat %t/objects/gitoid_blob_sha1/62/db4ab2efaf0b3df12e5004ff2b002936b94697 | FileCheck --check-prefix=BOM_FILE_SHA1 %s
+# RUN: cat %t/objects/gitoid_blob_sha256/6b/a8bcf3a1c3c7cafcfba5994ca7ee29bd47234f8616991717677836ce00dd95 | FileCheck --check-prefix=BOM_FILE_SHA256 %s
 
 # RUN: rm -rf %t/objects
 # RUN: ld.lld %t/omnibor.o -e main --omnibor=%t/omnibor_dir -o %t/omnibor_1.exe
 # RUN: llvm-readelf -n %t/omnibor_1.exe | FileCheck --check-prefix=BOM_NOTE_SECTION %s
-# RUN: cat %t/omnibor_dir/objects/gitoid_blob_sha1/3f/f57d57064dff16633a6e3acaaa08195b9073d5 | FileCheck --check-prefix=BOM_FILE_SHA1 %s
-# RUN: cat %t/omnibor_dir/objects/gitoid_blob_sha256/b3/949098052e5a6f9e43630ff1021970518ff78b4a6e983cc6602a8f1656a6c0 | FileCheck --check-prefix=BOM_FILE_SHA256 %s
+# RUN: cat %t/omnibor_dir/objects/gitoid_blob_sha1/62/db4ab2efaf0b3df12e5004ff2b002936b94697 | FileCheck --check-prefix=BOM_FILE_SHA1 %s
+# RUN: cat %t/omnibor_dir/objects/gitoid_blob_sha256/6b/a8bcf3a1c3c7cafcfba5994ca7ee29bd47234f8616991717677836ce00dd95 | FileCheck --check-prefix=BOM_FILE_SHA256 %s
 
 # RUN: rm -rf %t/env_omnibor_dir/objects
 # RUN: env OMNIBOR_DIR="%t/env_omnibor_dir" ld.lld %t/omnibor.o -e main --omnibor=%t/omnibor_dir -o %t/omnibor_2.exe
 # RUN: llvm-readelf -n %t/omnibor_2.exe | FileCheck --check-prefix=BOM_NOTE_SECTION %s
-# RUN: cat %t/env_omnibor_dir/objects/gitoid_blob_sha1/3f/f57d57064dff16633a6e3acaaa08195b9073d5 | FileCheck --check-prefix=BOM_FILE_SHA1 %s
-# RUN: cat %t/env_omnibor_dir/objects/gitoid_blob_sha256/b3/949098052e5a6f9e43630ff1021970518ff78b4a6e983cc6602a8f1656a6c0 | FileCheck --check-prefix=BOM_FILE_SHA256 %s
+# RUN: cat %t/env_omnibor_dir/objects/gitoid_blob_sha1/62/db4ab2efaf0b3df12e5004ff2b002936b94697 | FileCheck --check-prefix=BOM_FILE_SHA1 %s
+# RUN: cat %t/env_omnibor_dir/objects/gitoid_blob_sha256/6b/a8bcf3a1c3c7cafcfba5994ca7ee29bd47234f8616991717677836ce00dd95 | FileCheck --check-prefix=BOM_FILE_SHA256 %s
 
 # RUN: rm -rf %t/env_omnibor_dir/objects/
 # RUN: env OMNIBOR_DIR="%t/env_omnibor_dir" ld.lld %t/omnibor.o -e main -o %t/omnibor_3.exe
 # RUN: llvm-readelf -n %t/omnibor_3.exe | FileCheck --check-prefix=BOM_NOTE_SECTION %s
-# RUN: cat %t/env_omnibor_dir/objects/gitoid_blob_sha1/3f/f57d57064dff16633a6e3acaaa08195b9073d5 | FileCheck --check-prefix=BOM_FILE_SHA1 %s
-# RUN: cat %t/env_omnibor_dir/objects/gitoid_blob_sha256/b3/949098052e5a6f9e43630ff1021970518ff78b4a6e983cc6602a8f1656a6c0 | FileCheck --check-prefix=BOM_FILE_SHA256 %s
+# RUN: cat %t/env_omnibor_dir/objects/gitoid_blob_sha1/62/db4ab2efaf0b3df12e5004ff2b002936b94697 | FileCheck --check-prefix=BOM_FILE_SHA1 %s
+# RUN: cat %t/env_omnibor_dir/objects/gitoid_blob_sha256/6b/a8bcf3a1c3c7cafcfba5994ca7ee29bd47234f8616991717677836ce00dd95 | FileCheck --check-prefix=BOM_FILE_SHA256 %s
 
 # BOM_FILE_SHA1: gitoid blob sha1
-# BOM_FILE_SHA1: blob 6d0c1c525b24d874364f03928e77467d9ed1f2bb bom 432a5d88c4eb39bb994d57eb6252864b793f5204
+# BOM_FILE_SHA1: blob 9d6dac408438994dab9740d9a554599be282eb77 bom 3cdf9fc14ab04cb12e1b273a2fa890a60a80dc6b
 
 # BOM_FILE_SHA256: gitoid blob sha256
-# BOM_FILE_SHA256: blob e6b4258ddf91915260729639bf91d9a5664c1152fc400ce5916ed2c19b9258ef bom 7dccbc2f068cf761234df1c5c01b80a574c0c3b0d00accf19634b5488bfdb9e4
+# BOM_FILE_SHA256: blob 7be162961af2a2bd56813212b52af57b3592c79abf93e4dd25a6b220af6b001e bom effadaa78c3d317d42a31411d7e493c59bf77788f8683ecc2c3be754e7f15c12
 
 # BOM_NOTE_SECTION: Displaying notes found in: .note.omnibor
 # BOM_NOTE_SECTION-NEXT: Owner                Data size        Description
 # BOM_NOTE_SECTION-NEXT: 0x00000014       NT_GITOID_SHA1
-# BOM_NOTE_SECTION-NEXT: SHA1 GitOID: 3ff57d57064dff16633a6e3acaaa08195b9073d5
+# BOM_NOTE_SECTION-NEXT: SHA1 GitOID: 62db4ab2efaf0b3df12e5004ff2b002936b94697
 # BOM_NOTE_SECTION-NEXT: 0x00000020       NT_GITOID_SHA256
-# BOM_NOTE_SECTION-NEXT: SHA256 GitOID: b3949098052e5a6f9e43630ff1021970518ff78b4a6e983cc6602a8f1656a6c0
+# BOM_NOTE_SECTION-NEXT: SHA256 GitOID: 6ba8bcf3a1c3c7cafcfba5994ca7ee29bd47234f8616991717677836ce00dd95

--- a/llvm-project/lld/test/ELF/omnibor_test_2.s
+++ b/llvm-project/lld/test/ELF/omnibor_test_2.s
@@ -1,22 +1,21 @@
 # RUN: rm -rf %t && mkdir %t
-# RUN: llvm-mc -filetype=obj -triple=x86_64-pc-linux %S/Inputs/omnibor_add.s -o %t/omnibor_add.o
-# RUN: llvm-mc -filetype=obj -triple=x86_64-pc-linux %S/Inputs/omnibor_main.s -o %t/omnibor_main.o
+# RUN: llvm-mc -filetype=obj --omnibor-as=%t -triple=x86_64-pc-linux %S/Inputs/omnibor_add.s -o %t/omnibor_add.o
+# RUN: llvm-mc -filetype=obj --omnibor-as=%t -triple=x86_64-pc-linux %S/Inputs/omnibor_main.s -o %t/omnibor_main.o
 # RUN: ld.lld %t/omnibor_add.o %t/omnibor_main.o -e main --omnibor -o %t/omnibor_add.exe
 # RUN: llvm-readelf -n %t/omnibor_add.exe | FileCheck --check-prefix=BOM_NOTE_SECTION %s
-# RUN: cat %t/objects/gitoid_blob_sha1/7b/5cc942363892974b8089c3fb1cc92a1f807ba1 | FileCheck --check-prefix=BOM_FILE_SHA1 %s
-# RUN: cat %t/objects/gitoid_blob_sha256/17/42972fe1ab0fe742635cd6bb9c06ef3a8f7102b7e1f9c0eaaa70bb09684a4a | FileCheck --check-prefix=BOM_FILE_SHA256 %s
-
+# RUN: cat %t/objects/gitoid_blob_sha1/c0/951112087ba0a488720ac70fff24f6312133e3 | FileCheck --check-prefix=BOM_FILE_SHA1 %s
+# RUN: cat %t/objects/gitoid_blob_sha256/69/dd44e518950a04e5a64fd21922b7ba88294d1d80cc90808ef75e0dee7dd261 | FileCheck --check-prefix=BOM_FILE_SHA256 %s
 # BOM_FILE_SHA1: gitoid blob sha1
-# BOM_FILE_SHA1: blob 6d1df76ef597632db1f2547700f85fb4594dcf52 bom 6acc98b0749621cae7e199d06be49836d00b95ee
-# BOM_FILE_SHA1: blob 94c40262747e3093f3804587dd87a10584c0e56b bom 26c9992d3b1f610d20accdf677eb53cf45b554d2
+# BOM_FILE_SHA1: blob 980f5ba708b17f52a1273defc116409194ad6c04 bom 5efa5bb8d8d368521ea95bd2dd84a862f68cbc1c
+# BOM_FILE_SHA1: blob dd1bf717b9dfa1655c1a9724233644d07e369b4d bom 264d9eeb1db1be9cc93b76420e71516d69d25ff1
 
 # BOM_FILE_SHA256: gitoid blob sha256
-# BOM_FILE_SHA256: blob 32350816f9208b80c71b3afc9282f22a7796e1be6c91adb2d1672cbe0c0bd735 bom b0104b046077ffa030ceb715eedd60987fb34f5f5db4e109e8a35ed1f1f5e238
-# BOM_FILE_SHA256: blob c0ddd5ecc9a502502f25dab24b213efcf50f7eb0c6ba22b69fb10162499e70a4 bom b52743df5edad0f12680e6c1172df98d5f12d8c91d0868a72e277e7441868c12
+# BOM_FILE_SHA256: blob 39adae03571b754e376141f3ea08ac978f71420a6f9958eb80eec40dfadd6317 bom 217959aa06f15a4d6781d7902ae52cd1fdbb20ee5b8907f293d2aceaf2f8aad2
+# BOM_FILE_SHA256: blob 3ab2db3ff215c286c5546cbedea5bbd26c9cf5a10562eec2dc016d25de71cb9c bom db0170e1d04301f33163c7974f5f27b5ab248c987f9bbf7f0b1562c1e3c54db8
 
 # BOM_NOTE_SECTION: Displaying notes found in: .note.omnibor
 # BOM_NOTE_SECTION-NEXT: Owner                Data size        Description
 # BOM_NOTE_SECTION-NEXT: 0x00000014       NT_GITOID_SHA1
-# BOM_NOTE_SECTION-NEXT: SHA1 GitOID: 7b5cc942363892974b8089c3fb1cc92a1f807ba1
+# BOM_NOTE_SECTION-NEXT: SHA1 GitOID: c0951112087ba0a488720ac70fff24f6312133e3
 # BOM_NOTE_SECTION-NEXT: 0x00000020       NT_GITOID_SHA256
-# BOM_NOTE_SECTION-NEXT: SHA256 GitOID: 1742972fe1ab0fe742635cd6bb9c06ef3a8f7102b7e1f9c0eaaa70bb09684a4a
+# BOM_NOTE_SECTION-NEXT: SHA256 GitOID: 69dd44e518950a04e5a64fd21922b7ba88294d1d80cc90808ef75e0dee7dd261

--- a/llvm-project/llvm/include/llvm/MC/MCContext.h
+++ b/llvm-project/llvm/include/llvm/MC/MCContext.h
@@ -177,6 +177,9 @@ namespace llvm {
     /// The main file name if passed in explicitly.
     std::string MainFileName;
 
+    /// Path to store Omnibor info for Assembler
+    std::string OmniborAs;
+
     /// The dwarf file and directory tables from the dwarf .file directive.
     /// We now emit a line table for each compile unit. To reduce the prologue
     /// size of each line table, the files and directories used by each compile
@@ -677,6 +680,11 @@ namespace llvm {
 
     // Remaps all debug directory paths in-place as per the debug prefix map.
     void RemapDebugPaths();
+
+    /// OmniborAs
+    const std::string &getOmniborAs() const { return OmniborAs; }
+    void setOmniborAs(StringRef S) { OmniborAs = std::string(S); }
+    void setOmniborAs(const char *S) { OmniborAs = std::string(S); }
 
     /// Get the main file name for use in error messages and debug
     /// info. This can be set to ensure we've got the correct file name

--- a/llvm-project/llvm/lib/CodeGen/TargetLoweringObjectFileImpl.cpp
+++ b/llvm-project/llvm/lib/CodeGen/TargetLoweringObjectFileImpl.cpp
@@ -1113,9 +1113,9 @@ const MCExpr *TargetLoweringObjectFileELF::lowerDSOLocalEquivalent(
 }
 
 MCSection *TargetLoweringObjectFileELF::getSectionForOmniBor() const {
-  // .bom
+  // .note.omnibor
   return getContext().getELFSection(".note.omnibor", ELF::SHT_NOTE,
-                                    ELF::SHF_MERGE, 1);
+                                    ELF::SHF_ALLOC);
 }
 
 MCSection *TargetLoweringObjectFileELF::getSectionForCommandLines() const {

--- a/llvm-project/llvm/lib/MC/MCContext.cpp
+++ b/llvm-project/llvm/lib/MC/MCContext.cpp
@@ -148,6 +148,7 @@ void MCContext::reset() {
   Instances.clear();
   CompilationDir.clear();
   MainFileName.clear();
+  OmniborAs.clear();
   MCDwarfLineTablesCUMap.clear();
   SectionsForRanges.clear();
   MCGenDwarfLabelEntries.clear();

--- a/llvm-project/llvm/lib/MC/MCParser/ELFAsmParser.cpp
+++ b/llvm-project/llvm/lib/MC/MCParser/ELFAsmParser.cpp
@@ -672,6 +672,11 @@ EndStmt:
       }
   }
 
+  // If OMNIBOR is disabled, do not create a .note.omnibor section.
+  if (hasPrefix(SectionName, ".note.omnibor") &&
+      (getContext().getOmniborAs().empty()))
+    return false;
+
   MCSectionELF *Section =
       getContext().getELFSection(SectionName, Type, Flags, Size, GroupName,
                                  IsComdat, UniqueID, LinkedToSym);

--- a/llvm-project/llvm/test/MC/ELF/no-omnibor-test.s
+++ b/llvm-project/llvm/test/MC/ELF/no-omnibor-test.s
@@ -1,0 +1,39 @@
+# RUN: rm -rf %t && mkdir %t
+# RUN: env OMNIBOR_DIR="%t/env_omnibor_dir" llvm-mc -filetype=obj -triple=x86_64-linux-gnu %S/no-omnibor.s -o %t/no-omnibor-1.o
+# RUN: llvm-readelf -n %t/no-omnibor-1.o | FileCheck --check-prefix=OMNIBOR-1 %s
+# RUN: cat %t/env_omnibor_dir/objects/gitoid_blob_sha1/e1/c058d0ab49e12b2a0063be9b62efea9f2453c0 | FileCheck --check-prefix=OMNIBOR-SHA1-NOTE %s
+# RUN: cat %t/env_omnibor_dir/objects/gitoid_blob_sha256/cd/ae8735776aa8f7e20531f631dd73affbd992dfc7d464ec2586760edd071893 | FileCheck --check-prefix=OMNIBOR-SHA256-NOTE %s
+
+# RUN: llvm-mc --omnibor-as=%t -filetype=obj -triple=x86_64-linux-gnu %S/no-omnibor.s -o %t/no-omnibor-2.o
+# RUN: llvm-readelf -n %t/no-omnibor-2.o | FileCheck --check-prefix=OMNIBOR-1 %s
+# RUN: cat %t/objects/gitoid_blob_sha1/e1/c058d0ab49e12b2a0063be9b62efea9f2453c0 | FileCheck --check-prefix=OMNIBOR-SHA1-NOTE %s
+# RUN: cat %t/objects/gitoid_blob_sha256/cd/ae8735776aa8f7e20531f631dd73affbd992dfc7d464ec2586760edd071893 | FileCheck --check-prefix=OMNIBOR-SHA256-NOTE %s
+
+# RUN: rm -rf %t/env_omnibor_dir
+# RUN: rm -rf %t/objects
+# RUN: env OMNIBOR_DIR="%t/env_omnibor_dir" llvm-mc --omnibor-as=%t -filetype=obj -triple=x86_64-linux-gnu %S/no-omnibor.s -o %t/no-omnibor-3.o
+# RUN: llvm-readelf -n %t/no-omnibor-3.o | FileCheck --check-prefix=OMNIBOR-1 %s
+# RUN: cat %t/objects/gitoid_blob_sha1/e1/c058d0ab49e12b2a0063be9b62efea9f2453c0 | FileCheck --check-prefix=OMNIBOR-SHA1-NOTE %s
+# RUN: cat %t/objects/gitoid_blob_sha256/cd/ae8735776aa8f7e20531f631dd73affbd992dfc7d464ec2586760edd071893 | FileCheck --check-prefix=OMNIBOR-SHA256-NOTE %s
+
+# OMNIBOR-1: Displaying notes found in: .note.omnibor
+# OMNIBOR-1-NEXT:  Owner                Data size        Description
+# OMNIBOR-1-NEXT:  OMNIBOR              0x00000014       NT_GITOID_SHA1
+# OMNIBOR-1-NEXT:  SHA1 GitOID: e1c058d0ab49e12b2a0063be9b62efea9f2453c0
+# OMNIBOR-1-NEXT:  OMNIBOR              0x00000020       NT_GITOID_SHA256
+# OMNIBOR-1-NEXT:  SHA256 GitOID: cdae8735776aa8f7e20531f631dd73affbd992dfc7d464ec2586760edd071893
+
+# CHECK-NO-OMNIBOR-NOT: Displaying notes found in: .note.omnibor
+
+# OMNIBOR-SHA1-NOTE: gitoid blob sha1
+# OMNIBOR-SHA1-NOTE-NEXT: blob 52ebed6cf07d7ca81b88d47e905cb3c732e8ff3f
+
+# OMNIBOR-SHA256-NOTE: gitoid blob sha256
+# OMNIBOR-SHA256-NOTE-NEXT: blob 00b7792291a7818372031121c4556f3ac89fb7350be06423681604b7fb93873e
+
+# CHECK-OMNIBOR-2: Displaying notes found in: .note.omnibor
+# CHECK-OMNIBOR-2-NEXT: Owner                Data size        Description
+# CHECK-OMNIBOR-2-NEXT: OMNIBOR              0x00000014       NT_GITOID_SHA1
+# CHECK-OMNIBOR-2-NEXT: SHA1 GitOID: e1c058d0ab49e12b2a0063be9b62efea9f2453c0
+# CHECK-OMNIBOR-2-NEXT: OMNIBOR              0x00000020       NT_GITOID_SHA256
+# CHECK-OMNIBOR-2-NEXT: SHA256 GitOID: cdae8735776aa8f7e20531f631dd73affbd992dfc7d464ec2586760edd071893

--- a/llvm-project/llvm/test/MC/ELF/no-omnibor.s
+++ b/llvm-project/llvm/test/MC/ELF/no-omnibor.s
@@ -1,0 +1,37 @@
+	.text
+	.file	"hello.c"
+	.globl	main                            # -- Begin function main
+	.p2align	4, 0x90
+	.type	main,@function
+main:                                   # @main
+	.cfi_startproc
+# %bb.0:
+	pushq	%rbp
+	.cfi_def_cfa_offset 16
+	.cfi_offset %rbp, -16
+	movq	%rsp, %rbp
+	.cfi_def_cfa_register %rbp
+	subq	$16, %rsp
+	movl	$0, -4(%rbp)
+	movabsq	$.L.str, %rdi
+	movb	$0, %al
+	callq	printf
+	xorl	%eax, %eax
+	addq	$16, %rsp
+	popq	%rbp
+	.cfi_def_cfa %rsp, 8
+	retq
+.Lfunc_end0:
+	.size	main, .Lfunc_end0-main
+	.cfi_endproc
+                                        # -- End function
+	.type	.L.str,@object                  # @.str
+	.section	.rodata.str1.1,"aMS",@progbits,1
+.L.str:
+	.asciz	"\n hello"
+	.size	.L.str, 8
+
+	.ident	"clang version 14.0.1 (llvm-omnibor.git 7f56c2d1aa0242753f109f02b84c68190a48f2a8)"
+	.section	".note.GNU-stack","",@progbits
+	.addrsig
+	.addrsig_sym printf

--- a/llvm-project/llvm/test/MC/ELF/omnibor-test.s
+++ b/llvm-project/llvm/test/MC/ELF/omnibor-test.s
@@ -1,0 +1,44 @@
+# RUN: rm -rf %t && mkdir %t
+# RUN: env OMNIBOR_DIR="%t/env_omnibor_dir" llvm-mc -filetype=obj -triple=x86_64-linux-gnu %S/omnibor.s -o %t/omnibor-1.o
+# RUN: llvm-readelf -n %t/omnibor-1.o | FileCheck --check-prefix=OMNIBOR-1 %s
+# RUN: cat %t/env_omnibor_dir/objects/gitoid_blob_sha1/70/a1f821592cc68919c7d2aebbad02c58dfb5d09 | FileCheck --check-prefix=OMNIBOR-SHA1-NOTE %s
+# RUN: cat %t/env_omnibor_dir/objects/gitoid_blob_sha256/1c/3b786338c344b1a094d7df2d6c2dbdbecc9eb3987004a173cd1c07dd108faf | FileCheck --check-prefix=OMNIBOR-SHA256-NOTE %s
+
+# RUN: llvm-mc --omnibor-as=%t -filetype=obj -triple=x86_64-linux-gnu %S/omnibor.s -o %t/omnibor-2.o
+# RUN: llvm-readelf -n %t/omnibor-2.o | FileCheck --check-prefix=OMNIBOR-1 %s
+# RUN: cat %t/objects/gitoid_blob_sha1/70/a1f821592cc68919c7d2aebbad02c58dfb5d09 | FileCheck --check-prefix=OMNIBOR-SHA1-NOTE %s
+# RUN: cat %t/objects/gitoid_blob_sha256/1c/3b786338c344b1a094d7df2d6c2dbdbecc9eb3987004a173cd1c07dd108faf | FileCheck --check-prefix=OMNIBOR-SHA256-NOTE %s
+
+# RUN: rm -rf %t/env_omnibor_dir
+# RUN: rm -rf %t/objects
+# RUN: env OMNIBOR_DIR="%t/env_omnibor_dir" llvm-mc --omnibor-as=%t -filetype=obj -triple=x86_64-linux-gnu %S/omnibor.s -o %t/omnibor-3.o
+# RUN: llvm-readelf -n %t/omnibor-3.o | FileCheck --check-prefix=OMNIBOR-1 %s
+# RUN: cat %t/objects/gitoid_blob_sha1/70/a1f821592cc68919c7d2aebbad02c58dfb5d09 | FileCheck --check-prefix=OMNIBOR-SHA1-NOTE %s
+# RUN: cat %t/objects/gitoid_blob_sha256/1c/3b786338c344b1a094d7df2d6c2dbdbecc9eb3987004a173cd1c07dd108faf | FileCheck --check-prefix=OMNIBOR-SHA256-NOTE %s
+
+# RUN: rm -rf %t/env_omnibor_dir
+# RUN: rm -rf %t/objects
+# RUN: llvm-mc -filetype=obj -triple=x86_64-linux-gnu %S/omnibor.s -o %t/omnibor.o
+# RUN: llvm-readelf -n %t/omnibor.o | FileCheck --allow-empty --check-prefix=NO-OMNIBOR %s
+
+# OMNIBOR-1: Displaying notes found in: .note.omnibor
+# OMNIBOR-1-NEXT:  Owner                Data size        Description
+# OMNIBOR-1-NEXT:  OMNIBOR              0x00000014       NT_GITOID_SHA1
+# OMNIBOR-1-NEXT:  SHA1 GitOID: 70a1f821592cc68919c7d2aebbad02c58dfb5d09
+# OMNIBOR-1-NEXT:  OMNIBOR              0x00000020       NT_GITOID_SHA256
+# OMNIBOR-1-NEXT:  SHA256 GitOID: 1c3b786338c344b1a094d7df2d6c2dbdbecc9eb3987004a173cd1c07dd108faf
+
+# NO-OMNIBOR-NOT: Displaying notes found in: .note.omnibor
+
+# OMNIBOR-SHA1-NOTE: gitoid blob sha1
+# OMNIBOR-SHA1-NOTE: blob 46d7cf5af3c8e0649943db9d6ed5b248a083285a bom 4b6dc93e51a1b7506f40f408275e91acfd180d2c
+
+# OMNIBOR-SHA256-NOTE: gitoid blob sha256
+# OMNIBOR-SHA256-NOTE: blob 46872ea9d85ac8c80f548a1718b3d2e37695f495099423f01430c20c26ba73ee bom 5bc8896950cf038a3c9593b13c62257ba2e84e4e880591708f4e4305bf1f17cd
+
+# CHECK-OMNIBOR-2: Displaying notes found in: .note.omnibor
+# CHECK-OMNIBOR-2-NEXT: Owner                Data size        Description
+# CHECK-OMNIBOR-2-NEXT: OMNIBOR              0x00000014       NT_GITOID_SHA1
+# CHECK-OMNIBOR-2-NEXT: SHA1 GitOID: e1c058d0ab49e12b2a0063be9b62efea9f2453c0
+# CHECK-OMNIBOR-2-NEXT: OMNIBOR              0x00000020       NT_GITOID_SHA256
+# CHECK-OMNIBOR-2-NEXT: SHA256 GitOID: cdae8735776aa8f7e20531f631dd73affbd992dfc7d464ec2586760edd071893

--- a/llvm-project/llvm/test/MC/ELF/omnibor.s
+++ b/llvm-project/llvm/test/MC/ELF/omnibor.s
@@ -1,0 +1,51 @@
+	.text
+	.file	"hello.c"
+	.globl	main                            # -- Begin function main
+	.p2align	4, 0x90
+	.type	main,@function
+main:                                   # @main
+	.cfi_startproc
+# %bb.0:
+	pushq	%rbp
+	.cfi_def_cfa_offset 16
+	.cfi_offset %rbp, -16
+	movq	%rsp, %rbp
+	.cfi_def_cfa_register %rbp
+	subq	$16, %rsp
+	movl	$0, -4(%rbp)
+	movabsq	$.L.str, %rdi
+	movb	$0, %al
+	callq	printf
+	xorl	%eax, %eax
+	addq	$16, %rsp
+	popq	%rbp
+	.cfi_def_cfa %rsp, 8
+	retq
+.Lfunc_end0:
+	.size	main, .Lfunc_end0-main
+	.cfi_endproc
+                                        # -- End function
+	.type	.L.str,@object                  # @.str
+	.section	.rodata.str1.1,"aMS",@progbits,1
+.L.str:
+	.asciz	"\n hello"
+	.size	.L.str, 8
+
+	.ident	"clang version 14.0.1 (llvm-omnibor.git 7f56c2d1aa0242753f109f02b84c68190a48f2a8)"
+	.section	.note.omnibor,"a",@note
+	.long	8
+	.long	20
+	.long	1
+	.ascii	"OMNIBOR"
+	.zero	1
+	.ascii	"Km\311>Q\241\267Po@\364\b'^\221\254\375\030\r,"
+	.long	8
+	.long	32
+	.long	2
+	.ascii	"OMNIBOR"
+	.zero	1
+	.ascii	"[\310\211iP\317\003\212<\225\223\261<b%{\242\350NN\210\005\221p\217NC\005\277\037\027\315"
+	.section	.rodata.str1.1,"aMS",@progbits,1
+	.section	".note.GNU-stack","",@progbits
+	.addrsig
+	.addrsig_sym printf

--- a/llvm-project/llvm/tools/llvm-mc/llvm-mc.cpp
+++ b/llvm-project/llvm/tools/llvm-mc/llvm-mc.cpp
@@ -45,6 +45,10 @@ static mc::RegisterMCTargetOptionsFlags MOF;
 
 static cl::OptionCategory MCCategory("MC Options");
 
+static cl::opt<std::string> OmniborAs("omnibor-as",
+                                      cl::desc("<Generate Omnibor data>"),
+                                      cl::init(""), cl::cat(MCCategory));
+
 static cl::opt<std::string> InputFilename(cl::Positional,
                                           cl::desc("<input file>"),
                                           cl::init("-"), cl::cat(MCCategory));
@@ -486,6 +490,12 @@ int main(int argc, char **argv) {
     const auto &KV = StringRef(Arg).split('=');
     Ctx.addDebugPrefixMapEntry(std::string(KV.first), std::string(KV.second));
   }
+
+  const char *env = ::getenv("OMNIBOR_DIR");
+  if (!OmniborAs.empty())
+    Ctx.setOmniborAs(OmniborAs);
+  else if (env)
+    Ctx.setOmniborAs(env);
   if (!MainFileName.empty())
     Ctx.setMainFileName(MainFileName);
   if (GenDwarfForAssembly)


### PR DESCRIPTION
This adds OmniBOR support for assembly files (with extension .s).
- It can be enabled by setting the environment variable (OMNIBOR_DIR=<path to store omnibor data>)
- New assembler option "-omnibor-as <path to store omnibor data>" has been added to llvm-mc and cc1as.
- Adjust lld test case to use the new option in llvm-mc
- Remove SHF_MERGE flag for .note.omnibor section