### PR TITLE
Create a metadata file named as the artifact id of the output file

### DIFF
--- a/llvm-project/clang/include/clang/Basic/CodeGenOptions.h
+++ b/llvm-project/clang/include/clang/Basic/CodeGenOptions.h
@@ -183,6 +183,10 @@ public:
   /// The string containing the gitoid of the omnibor file.
   std::string RecordOmniBor;
 
+  /// The string containing the commandline for the Omnibor metadata,
+  /// if non-empty.
+  std::string OmniborCommandLine;
+
   /// List of dependent source/header files.
   /// This is shared with DependencyOuputOptions.
   /// This has same contents as Dependencies in DependencyCollector.

--- a/llvm-project/clang/include/clang/Driver/Options.td
+++ b/llvm-project/clang/include/clang/Driver/Options.td
@@ -4991,6 +4991,9 @@ def record_command_line : Separate<["-"], "record-command-line">,
 def record_omnibor: Separate<["-"], "record-omnibor">,
   HelpText<"The string to embed in the .note.omnibor section.">,
   MarshallingInfoString<CodeGenOpts<"RecordOmniBor">>;
+def omnibor_command_line : Separate<["-"], "omnibor-command-line">,
+  HelpText<"The command line string to be recorded in Omnibor metadata file.">,
+  MarshallingInfoString<CodeGenOpts<"OmniborCommandLine">>;
 def compress_debug_sections_EQ : Joined<["-", "--"], "compress-debug-sections=">,
     HelpText<"DWARF debug sections compression type">, Values<"none,zlib">,
     NormalizedValuesScope<"llvm::DebugCompressionType">, NormalizedValues<["None", "Z"]>,

--- a/llvm-project/clang/lib/CodeGen/CodeGenModule.cpp
+++ b/llvm-project/clang/lib/CodeGen/CodeGenModule.cpp
@@ -6452,6 +6452,7 @@ static std::string ComputeSHA1OmniBorData(CodeGenModule &CGM,
   gitoid = Result.str();
 
   SmallString<128> gitoidPath(CGM.getCodeGenOpts().RecordOmniBor);
+  llvm::sys::path::append(gitoidPath, "objects");
   llvm::sys::path::append(gitoidPath, "gitoid_blob_sha1");
   llvm::sys::path::append(gitoidPath, gitoidHex.substr(0, 2));
   std::error_code EC;
@@ -6496,6 +6497,7 @@ static std::string ComputeSHA256OmniBorData(CodeGenModule &CGM,
   gitoid = Result.str();
 
   SmallString<128> gitoidPath(CGM.getCodeGenOpts().RecordOmniBor);
+  llvm::sys::path::append(gitoidPath, "objects");
   llvm::sys::path::append(gitoidPath, "gitoid_blob_sha256");
   llvm::sys::path::append(gitoidPath, gitoidHex.substr(0, 2));
   std::error_code EC;

--- a/llvm-project/clang/test/CodeGen/omnibor_test.c
+++ b/llvm-project/clang/test/CodeGen/omnibor_test.c
@@ -1,5 +1,12 @@
 // RUN: rm -rf %t && mkdir %t
 
+// RUN: rm -f objects/gitoid_blob_sha1/0b/e9b91c3e456c910b32afc862ffd073b7c61d5f
+// RUN: env OMNIBOR_DIR= %clang -c -frecord-omnibor=%t %S/Inputs/omnibor.c -I%S/Inputs/omnibor.h
+// RUN: llvm-readelf -n omnibor.o | FileCheck --check-prefix=BOM_NOTE_SECTION %s
+// RUN: cat %t/objects/gitoid_blob_sha1/0b/e9b91c3e456c910b32afc862ffd073b7c61d5f | FileCheck --check-prefix=BOM_FILE_SHA1_CONTENTS %s
+// RUN: cat %t/objects/gitoid_blob_sha256/58/ed318e337ad6260f471c086e9c9985543c5fbd507c3b44924f5af37bd0ea96 | FileCheck --check-prefix=BOM_FILE_SHA256_CONTENTS %s
+// RUN: cat %t/metadata/llvm/17274786fd44c95cae7ccb2d0b29ca1738c3cbb1 | FileCheck --check-prefix=METADATA_CONTENTS %s
+
 // RUN: %clang -c -frecord-omnibor=%t -o %t/omnibor_1.o %S/Inputs/omnibor.c -I%S/Inputs/omnibor.h
 // RUN: llvm-readelf -n %t/omnibor_1.o | FileCheck --check-prefix=BOM_NOTE_SECTION %s
 // RUN: cat %t/objects/gitoid_blob_sha1/0b/e9b91c3e456c910b32afc862ffd073b7c61d5f | FileCheck --check-prefix=BOM_FILE_SHA1_CONTENTS %s
@@ -27,12 +34,6 @@
 // RUN: cat %t/objects/gitoid_blob_sha1/0b/e9b91c3e456c910b32afc862ffd073b7c61d5f | FileCheck --check-prefix=BOM_FILE_SHA1_CONTENTS %s
 // RUN: cat %t/objects/gitoid_blob_sha256/58/ed318e337ad6260f471c086e9c9985543c5fbd507c3b44924f5af37bd0ea96 | FileCheck --check-prefix=BOM_FILE_SHA256_CONTENTS %s
 
-// RUN: rm -f objects/gitoid_blob_sha1/0b/e9b91c3e456c910b32afc862ffd073b7c61d5f
-// RUN: env OMNIBOR_DIR= %clang -c -frecord-omnibor=%t %S/Inputs/omnibor.c -I%S/Inputs/omnibor.h
-// RUN: llvm-readelf -n omnibor.o | FileCheck --check-prefix=BOM_NOTE_SECTION %s
-// RUN: cat %t/objects/gitoid_blob_sha1/0b/e9b91c3e456c910b32afc862ffd073b7c61d5f | FileCheck --check-prefix=BOM_FILE_SHA1_CONTENTS %s
-// RUN: cat %t/objects/gitoid_blob_sha256/58/ed318e337ad6260f471c086e9c9985543c5fbd507c3b44924f5af37bd0ea96 | FileCheck --check-prefix=BOM_FILE_SHA256_CONTENTS %s
-
 // BOM_NOTE_SECTION: Displaying notes found in: .note.omnibor
 // BOM_NOTE_SECTION: Owner                Data size        Description
 // BOM_NOTE_SECTION: OMNIBOR               0x00000014       NT_GITOID_SHA1
@@ -47,3 +48,7 @@
 // BOM_FILE_SHA256_CONTENTS: gitoid:blob:sha256
 // BOM_FILE_SHA256_CONTENTS: blob 465be75836446b37f31c5db1f29a8689f37cd5625d4b30237877703fc1070f5e
 // BOM_FILE_SHA256_CONTENTS: blob 8ad020236bd23736a75699ba4e83f52593d61c4c9f8d5932b57fce011f832bf8
+
+// METADATA_CONTENTS: output: omnibor.o
+// METADATA_CONTENTS_NEXT: input {{.*}}/omnibor.c
+// METADATA_CONTENTS_NEXT: input {{.*}}/omnibor.h


### PR DESCRIPTION
The metadata file is created under ${OMNIBOR_DIR}/metadata/llvm directory and currently contains the dependencies (tagged as input or output) and the build command. 