### PR TITLE
Do not include shared objects in the Input Manifest

### DIFF
--- a/llvm-project/lld/ELF/SyntheticSections.cpp
+++ b/llvm-project/lld/ELF/SyntheticSections.cpp
@@ -140,7 +140,7 @@ static void genArtifactIds(FileHashBomMap &BomMap) {
   std::string OutFilename(config->outputFile.str());
   // StringRef BomFile = StringRef(OutFilename);
 
-  // Emit gitbom info for Outputfile
+  // Emit OmniBOR info for Outputfile
   // Getting the hash of the outputfile is tricky as the file has not been
   // written at this point.
   MetadataContents.append("\noutput: ");
@@ -167,7 +167,10 @@ static void genArtifactIds(FileHashBomMap &BomMap) {
     bomData.sha1_artifact_id = convertToHex(Result_sha1);
 
     // Collect Metadata
-    config->SHA1_MetadataContents.append("\ninput: ");
+    if (path.contains(".so"))
+      config->SHA1_MetadataContents.append("\ndynlib: ");
+    else
+      config->SHA1_MetadataContents.append("\ninput: ");
     config->SHA1_MetadataContents.append(bomData.sha1_artifact_id);
     config->SHA1_MetadataContents.append(" path: ");
     SmallString<128> InFilename(path);
@@ -180,7 +183,9 @@ static void genArtifactIds(FileHashBomMap &BomMap) {
     auto Result_sha256 = SHA256_Hash.final();
     bomData.sha256_artifact_id = convertToHex(Result_sha256);
 
-    BomMap[path.str()] = bomData;
+    // Do not include gitoids for shared objects in the Input Manifest.
+    if (!path.contains(".so"))
+      BomMap[path.str()] = bomData;
   }
 }
 

--- a/llvm-project/lld/test/ELF/Inputs/omnibor-add.s
+++ b/llvm-project/lld/test/ELF/Inputs/omnibor-add.s
@@ -1,0 +1,27 @@
+	.text
+	.file	"add.c"
+	.globl	add                             # -- Begin function add
+	.p2align	4, 0x90
+	.type	add,@function
+add:                                    # @add
+	.cfi_startproc
+# %bb.0:
+	pushq	%rbp
+	.cfi_def_cfa_offset 16
+	.cfi_offset %rbp, -16
+	movq	%rsp, %rbp
+	.cfi_def_cfa_register %rbp
+	movl	%edi, -4(%rbp)
+	movl	%esi, -8(%rbp)
+	movl	-4(%rbp), %eax
+	addl	-8(%rbp), %eax
+	popq	%rbp
+	.cfi_def_cfa %rsp, 8
+	retq
+.Lfunc_end0:
+	.size	add, .Lfunc_end0-add
+	.cfi_endproc
+                                        # -- End function
+	.ident	"clang version 14.0.1 (https://github.com/omnibor/llvm-omnibor.git 53fc4b237f97aab8100a8d733a6b99e6869b5adc)"
+	.section	".note.GNU-stack","",@progbits
+	.addrsig

--- a/llvm-project/lld/test/ELF/Inputs/omnibor-useadd.s
+++ b/llvm-project/lld/test/ELF/Inputs/omnibor-useadd.s
@@ -1,0 +1,30 @@
+	.text
+	.file	"useadd.c"
+	.globl	main                            # -- Begin function main
+	.p2align	4, 0x90
+	.type	main,@function
+main:                                   # @main
+	.cfi_startproc
+# %bb.0:
+	pushq	%rbp
+	.cfi_def_cfa_offset 16
+	.cfi_offset %rbp, -16
+	movq	%rsp, %rbp
+	.cfi_def_cfa_register %rbp
+	subq	$16, %rsp
+	movl	$0, -4(%rbp)
+	movl	$3, %esi
+	movl	%esi, %edi
+	callq	add
+	addq	$16, %rsp
+	popq	%rbp
+	.cfi_def_cfa %rsp, 8
+	retq
+.Lfunc_end0:
+	.size	main, .Lfunc_end0-main
+	.cfi_endproc
+                                        # -- End function
+	.ident	"clang version 14.0.1 (https://github.com/omnibor/llvm-omnibor.git 53fc4b237f97aab8100a8d733a6b99e6869b5adc)"
+	.section	".note.GNU-stack","",@progbits
+	.addrsig
+	.addrsig_sym add

--- a/llvm-project/lld/test/ELF/omnibor_test_shared.s
+++ b/llvm-project/lld/test/ELF/omnibor_test_shared.s
@@ -1,0 +1,25 @@
+# RUN: rm -rf %t && mkdir %t
+# RUN: llvm-mc -filetype=obj -triple=x86_64-pc-linux %S/Inputs/omnibor-add.s -o %t/add.o
+# RUN: ld.lld %t/add.o -shared -o %t/libadd.so
+# RUN: llvm-mc -filetype=obj -triple=x86_64-pc-linux %S/Inputs/omnibor-useadd.s -o %t/useadd.o
+# RUN: ld.lld -e main --omnibor=%t/omnibor_dir %t/useadd.o -L%t -ladd -o %t/omnibor.exe
+
+# RUN: ARTIFACT_ID=`git hash-object %t/omnibor.exe`
+
+# RUN: cat %t/omnibor_dir/objects/gitoid_blob_sha1/4d/5d15346cc50f375415126f59c68557eaad5b91 | FileCheck --check-prefix=BOM_FILE_SHA1 %s
+# RUN: cat %t/omnibor_dir/objects/gitoid_blob_sha256/96/fc39fafd5b65d4d030ba269a5d05dd7cf177bb6f4ef67a0b1e62ddbc171062 | FileCheck --check-prefix=BOM_FILE_SHA256 %s
+# RUN: cat %t/omnibor_dir/metadata/llvm/$ARTIFACT_ID | FileCheck --check-prefix=METADATA_CONTENTS %s
+
+# BOM_FILE_SHA1: gitoid blob sha1
+# BOM_FILE_SHA1: blob b5c9e6237f9381f5c9ce8d38d8db8b9071c46e9d
+
+# BOM_FILE_SHA256: gitoid blob sha256
+# BOM_FILE_SHA256: blob 53d9ba61c4c2e290bdafaa0528265b2854fb65356c4f00e085d6be895cb98343
+
+# CHECK-NO-OMNIBOR-NOT: Displaying notes found in: .note.omnibor
+
+# METADATA_CONTENTS: output: {{.*}} path: {{.*}}omnibor.exe
+# METADATA_CONTENTS: input: {{.*}} path: {{.*}}useadd.o
+# METADATA_CONTENTS: dynlib: {{.*}} path: {{.*}}libadd.so
+# METADATA_CONTENTS: build_cmd: ld.lld {{.*}}
+==== End of raw info for this process


### PR DESCRIPTION
Shared objects could potentially change at runtime and hence are not to be captured as build time dependencies. But they are still recorded in the metadata under 'dynlib' type. This behavior makes it compatible with bomsh tooling.